### PR TITLE
Revamp README.md to contain more beginner-friendly informations

### DIFF
--- a/ABOUT.md
+++ b/ABOUT.md
@@ -1,0 +1,26 @@
+# ReaTeam Script Repository
+
+Community-maintained collection of scripts for REAPER
+
+[https://github.com/ReaTeam/ReaScripts](https://github.com/ReaTeam/ReaScripts)
+
+## ReaTeam members
+
+- [Argitoth](http://forum.cockos.com/member.php?u=7973)
+- [Breeder](http://forum.cockos.com/member.php?u=27094)
+- [cfillion](http://forum.cockos.com/member.php?u=98780)
+- [HeDa](http://forum.cockos.com/member.php?u=47822)
+- [mpl](http://forum.cockos.com/member.php?u=70694)
+- [nofish](http://forum.cockos.com/member.php?u=6870)
+- [planetnine](http://forum.cockos.com/member.php?u=6549)
+- [spk77](http://forum.cockos.com/member.php?u=49553)
+- [X-Raym](http://forum.cockos.com/member.php?u=58284)
+
+## Donation
+
+You can always donate to some members below if you like their stuff:
+
+- [HeDa](https://www.patreon.com/heda?ty=h)
+- [mpl](https://www.paypal.me/donate2mpl)
+- [spk77](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=5NUK834ZGR5NU&lc=FI&item_name=SPK77%20scripts%20for%20REAPER&currency_code=EUR&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted)
+- [X-Raym](http://www.extremraym.com/en/donation/)

--- a/README.md
+++ b/README.md
@@ -1,16 +1,34 @@
-# ReaScripts
+# ReaTeam Script Repository
 
-A part of Cockos Reaper scripts collection.  
-This part holds stuff from different places and gives you possibility to download it by one click instead of hard browsing stash, forum threads, etc.
+Community-maintained collection of scripts for REAPER
 
-Other big parts are:
+[![Build Status](https://travis-ci.org/ReaTeam/ReaScripts.svg?branch=master)](https://travis-ci.org/ReaTeam/ReaScripts)
 
-- [X-Raym repo](https://github.com/X-Raym/REAPER-ReaScripts)
-- [mpl repo](https://github.com/MichaelPilyavskiy/ReaScripts)
+Other similar repositories:
 
-### Info
+- [ReaTeam/JSFX](https://github.com/ReaTeam/JSFX)
+- [X-Raym/REAPER-ReaScripts](https://github.com/X-Raym/REAPER-ReaScripts)
+- [mpl/ReaScripts](https://github.com/MichaelPilyavskiy/ReaScripts)
 
-Related thread placed [here](http://forum.cockos.com/showthread.php?t=169127)
+## Installation
+
+Copy and paste this URL in Extensions > ReaPack > Import a repository:
+
+```
+https://github.com/ReaTeam/ReaScripts/raw/master/index.xml
+```
+
+## Discussing
+
+Talk about this repository and ReaTeam in this thread on the REAPER forums:  
+http://forum.cockos.com/showthread.php?t=169127
+
+## Contributing
+
+Fork this repository, add your scripts in an appropriate category (directory)
+and send us a pull request.
+
+[Packaging Documentation](https://github.com/cfillion/reapack-index/wiki/Packaging-Documentation)
 
 ### Source code is taken from:
 

--- a/README.md
+++ b/README.md
@@ -29,32 +29,3 @@ Fork this repository, add your scripts in an appropriate category (directory)
 and send us a pull request.
 
 [Packaging Documentation](https://github.com/cfillion/reapack-index/wiki/Packaging-Documentation)
-
-### Source code is taken from:
-
-- [spk77 Reaper Stash page](http://stash.reaper.fm/u/spk77)
-- [planetnine Reaper Stash page](http://stash.reaper.fm/u/planetnine)
-- [Argitoth forum posts](http://forum.cockos.com/member.php?u=7973)
-- [nofish GitHub](https://github.com/nofishonfriday/ReaScripts)
-- Cockos forum, Reaper Stash and many other places, where scripts were chaotically placed
-
-### ReaTeam:
-
-- [Argitoth](http://forum.cockos.com/member.php?u=7973)
-- [Breeder](http://forum.cockos.com/member.php?u=27094)
-- [cfillion](http://forum.cockos.com/member.php?u=98780)
-- [HeDa](http://forum.cockos.com/member.php?u=47822)
-- [mpl](http://forum.cockos.com/member.php?u=70694)
-- [nofish](http://forum.cockos.com/member.php?u=6870)
-- [planetnine](http://forum.cockos.com/member.php?u=6549)
-- [spk77](http://forum.cockos.com/member.php?u=49553)
-- [X-Raym](http://forum.cockos.com/member.php?u=58284)
-
-### Donation
-
-You can always donate to some members below if you like their stuff:
-
-- [HeDa](https://www.patreon.com/heda?ty=h)
-- [mpl](https://www.paypal.me/donate2mpl)
-- [spk77](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=5NUK834ZGR5NU&lc=FI&item_name=SPK77%20scripts%20for%20REAPER&currency_code=EUR&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted)
-- [X-Raym](http://www.extremraym.com/en/donation/)


### PR DESCRIPTION
I tried to improve the documentation of this repository a little bit:
- Added basic installation/contributing instructions in README.md (similar to what's in JSFX's readme)
- Moved part of it in a special ABOUT.md file for ReaPack's [about dialog](https://i.imgur.com/4ywfTMf.png):
  - Installation instructions are not useful if the repository is already installed... 😛 
  - Since the ReaTeam member list is already available [here](https://github.com/orgs/ReaTeam/people), it's probably more useful in ABOUT.md than the README
- Removed the "code taken from" section. I think it would be better to write that information in the scripts themselve, if required, rather than in the readme.

Preview: [README.md](https://github.com/ReaTeam/ReaScripts/blob/new-readme/README.md) & [ABOUT.md](https://github.com/ReaTeam/ReaScripts/blob/new-readme/ABOUT.md)

ping @MichaelPilyavskiy as you wrote the original readme: do you have comments on this before merging?
(Also feel free to make other changes to these files in the [`new-readme`](https://github.com/ReaTeam/ReaScripts/tree/new-readme) branch if you want)
