### PR TITLE
Simplify the description of remaining scripts

### DIFF
--- a/Envelopes/js_Envelope LFO generator and shaper.lua
+++ b/Envelopes/js_Envelope LFO generator and shaper.lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name: js_Envelope LFO generator and shaper.lua
+ * ReaScript Name: Envelope LFO generator and shaper
  * Description: LFO generator and shaper - Envelope version
  * Instructions:  
  *         DRAWING ENVELOPES

--- a/Items Editing/js_Remove all CCs, pitch, channel pressure and program change events from all tracks.lua
+++ b/Items Editing/js_Remove all CCs, pitch, channel pressure and program change events from all tracks.lua
@@ -1,5 +1,5 @@
 --[[
-ReaScript name: js_Remove all CCs, pitch, channel pressure and program change events from all tracks.lua
+ReaScript name: Remove all CCs, pitch, channel pressure and program change events from all tracks
 Version: 1.00
 Author: juliansader
 Website: http://forum.cockos.com/showthread.php?t=179065

--- a/MIDI Editor/js_1-sided warp (accelerate) selected events in lane under mouse.lua
+++ b/MIDI Editor/js_1-sided warp (accelerate) selected events in lane under mouse.lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name:  js_1-sided warp (accelerate) selected events in lane under mouse.lua
+ * ReaScript Name:  1-sided warp (accelerate) selected events in lane under mouse
  * Description:  A simple script for warping the positions of MIDI events.
  *               The script only affects events in the MIDI editor lane under the mouse cursor.
  *               NB: Useful for changing a linear ramp into a parabolic (or other power) curve.

--- a/MIDI Editor/js_2-sided warp (and stretch) selected events in lane under mouse.lua
+++ b/MIDI Editor/js_2-sided warp (and stretch) selected events in lane under mouse.lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name:  js_2-sided warp (and stretch) selected events in lane under mouse.lua
+ * ReaScript Name:  2-sided warp (and stretch) selected events in lane under mouse
  * Description:  A simple script for warping and stretching the positions of MIDI events.
  *               The script only affects events in the MIDI editor lane under the mouse cursor.
  *               NB: Useful for changing a linear CC ramp into more complex logistic-type curves.

--- a/MIDI Editor/js_Arch selected events in lane under mouse with linear or power curve.lua
+++ b/MIDI Editor/js_Arch selected events in lane under mouse with linear or power curve.lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name:  js_Arch selected events in lane under mouse with linear or power curve.lua
+ * ReaScript Name:  Arch selected events in lane under mouse with linear or power curve
  * Description:  Arch selected CCs or velocities in lane under mouse towards mouse position, using a linear or power curve.
  *               The shape of the curve can be changed with the mousewheel.
  * Instructions:  There are two ways in which this script can be run:  

--- a/MIDI Editor/js_Arch selected events in lane under mouse with sine curve.lua
+++ b/MIDI Editor/js_Arch selected events in lane under mouse with sine curve.lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name:  js_Arch selected events in lane under mouse with sine curve.lua
+ * ReaScript Name:  Arch selected events in lane under mouse with sine curve
  * Description:  Arch selected CCs or velocities in lane under mouse towards mouse position, using a sine or sine power curve.
  *               The shape of the curve can be changed with the mousewheel.
  * Instructions:  There are two ways in which this script can be run:  

--- a/MIDI Editor/js_Compress or expand selected CC or velocity events using mousewheel.lua
+++ b/MIDI Editor/js_Compress or expand selected CC or velocity events using mousewheel.lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name:  js_Compress or expand selected CC or velocity events using mousewheel.lua
+ * ReaScript Name:  Compress or expand selected CC or velocity events using mousewheel
  * Description:  Compress or expand CC or velocity using mousewheel
  * Instructions:  There are two ways in which this script can be run:  
  *                  1) First, the script can be linked to its own shortcut key (such as "Ctrl+C"), in which case

--- a/MIDI Editor/js_Deselect all events outside time selection (from all tracks).lua
+++ b/MIDI Editor/js_Deselect all events outside time selection (from all tracks).lua
@@ -1,5 +1,5 @@
 --[[
-ReaScript name: js_Deselect all MIDI events outside time selection (from all tracks).lua
+ReaScript name: Deselect all MIDI events outside time selection (from all tracks)
 Version: 1.11
 Author: juliansader
 Licence: GPL v3

--- a/MIDI Editor/js_Draw linear or curved ramps in real time, chasing start values.lua
+++ b/MIDI Editor/js_Draw linear or curved ramps in real time, chasing start values.lua
@@ -1,5 +1,5 @@
 --[[
-ReaScript name: js_Draw linear or curved ramps in real time, chasing start values.lua
+ReaScript name: Draw linear or curved ramps in real time, chasing start values
 Version: 2.10
 Author: juliansader
 Screenshot: http://stash.reaper.fm/27627/Draw%20linear%20or%20curved%20ramps%20in%20real%20time%2C%20chasing%20start%20values%20-%20Copy.gif

--- a/MIDI Editor/js_Draw linear or curved ramps in real time.lua
+++ b/MIDI Editor/js_Draw linear or curved ramps in real time.lua
@@ -1,5 +1,5 @@
 --[[
-ReaScript name: js_Draw linear or curved ramps in real time.lua
+ReaScript name: Draw linear or curved ramps in real time
 Version: 2.10
 Author: juliansader
 Screenshot: http://stash.reaper.fm/27627/Draw%20linear%20or%20curved%20ramps%20in%20real%20time%2C%20chasing%20start%20values%20-%20Copy.gif

--- a/MIDI Editor/js_Draw sine curve in real time, chasing start values.lua
+++ b/MIDI Editor/js_Draw sine curve in real time, chasing start values.lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name:  js_Draw sine curve in real time, chasing start values.lua
+ * ReaScript Name:  Draw sine curve in real time, chasing start values
  * Description: Draw sine-shped curves of CC and pitchwheel events in real time.
  *              An improvement over REAPER's built-in "Linear ramp CC events" mouse action:
  *               1) If snap to grid is enabled in the MIDI editor, the endpoints of the 

--- a/MIDI Editor/js_Draw sine curve in real time.lua
+++ b/MIDI Editor/js_Draw sine curve in real time.lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name:  js_Draw sine curve in real time.lua
+ * ReaScript Name:  Draw sine curve in real time
  * Description: Draw sine-shapedcurve of CC and pitchwheel events in real time.
  *              An improvement over REAPER's built-in "Linear ramp CC events" mouse action:
  *               1) If snap to grid is enabled in the MIDI editor, the endpoints of the 

--- a/MIDI Editor/js_Insert CC or pitch at mouse position, leaving other selected.lua
+++ b/MIDI Editor/js_Insert CC or pitch at mouse position, leaving other selected.lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name:  js_Insert CC or pitch at mouse position, leaving other selected.lua
+ * ReaScript Name:  Insert CC or pitch at mouse position, leaving other selected
  * Description:  A simple script to insert a CC events, while leaving other events selected.
  *               Strangely, current (v5.20) versions of REAPER does not offer any mouse modifiers 
  *                   for inserting CC events while keeping already-selected events selected.  

--- a/MIDI Editor/js_Insert linear or shaped ramps between selected CCs or pitches in lane under mouse.lua
+++ b/MIDI Editor/js_Insert linear or shaped ramps between selected CCs or pitches in lane under mouse.lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name:  js_Insert linear or shaped ramps between selected CCs or pitches in lane under mouse.lua
+ * ReaScript Name:  Insert linear or shaped ramps between selected CCs or pitches in lane under mouse
  * Description:   Useful for quickly adding ramps between 'nodes'.
  *                Useful for smoothing transitions between CCs that were drawn at low resolution.
  *

--- a/MIDI Editor/js_LFO Tool (MIDI editor version, insert CCs in time selection in lane under mouse).lua
+++ b/MIDI Editor/js_LFO Tool (MIDI editor version, insert CCs in time selection in lane under mouse).lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name: js_LFO Tool (MIDI editor version, insert CCs in time selection in lane under mouse).lua
+ * ReaScript Name: LFO Tool (MIDI editor version, insert CCs in time selection in lane under mouse)
  * Description: LFO generator and shaper - MIDI editor version
  *              Draw fancy LFO curves in REAPER's piano roll.
  * Instructions:  

--- a/MIDI Editor/js_LFO Tool (MIDI editor version, insert CCs in time selection in last clicked lane).lua
+++ b/MIDI Editor/js_LFO Tool (MIDI editor version, insert CCs in time selection in last clicked lane).lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name: js_LFO Tool (MIDI editor version, insert CCs in time selection in last clicked lane).lua
+ * ReaScript Name: LFO Tool (MIDI editor version, insert CCs in time selection in last clicked lane)
  * Description: LFO generator and shaper - MIDI editor version
  *              Draw fancy LFO curves in REAPER's piano roll.
  * Instructions:  

--- a/MIDI Editor/js_LFO Tool (MIDI editor version, insert CCs under selected notes in lane under mouse).lua
+++ b/MIDI Editor/js_LFO Tool (MIDI editor version, insert CCs under selected notes in lane under mouse).lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name: js_LFO Tool (MIDI editor version, insert CCs under selected notes in lane under mouse).lua
+ * ReaScript Name: LFO Tool (MIDI editor version, insert CCs under selected notes in lane under mouse)
  * Description: LFO generator and shaper - MIDI editor version
  *              Draw fancy LFO curves in REAPER's piano roll.
  * Instructions:  

--- a/MIDI Editor/js_LFO Tool (MIDI editor version, insert CCs under selected notes in last clicked lane).lua
+++ b/MIDI Editor/js_LFO Tool (MIDI editor version, insert CCs under selected notes in last clicked lane).lua
@@ -1,5 +1,5 @@
  --[[
-  * ReaScript Name: js_LFO Tool (MIDI editor version, insert CCs under selected notes in last clicked lane).lua
+  * ReaScript Name: LFO Tool (MIDI editor version, insert CCs under selected notes in last clicked lane)
   * Description: LFO generator and shaper - MIDI editor version
   *              Draw fancy LFO curves in REAPER's piano roll.
   * Instructions:  

--- a/MIDI Editor/js_MIDI Inspector.lua
+++ b/MIDI Editor/js_MIDI Inspector.lua
@@ -1,5 +1,5 @@
 --[[
-ReaScript name: js_MIDI Inspector.lua
+ReaScript name: MIDI Inspector
 Version: 0.95
 Author: juliansader
 Screenshot: http://stash.reaper.fm/28295/js_MIDI%20Inspector.jpeg

--- a/MIDI Editor/js_MIDI editor LFO generator and shaper.lua
+++ b/MIDI Editor/js_MIDI editor LFO generator and shaper.lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name: js_MIDI editor LFO generator and shaper.lua
+ * ReaScript Name: MIDI editor LFO generator and shaper
  * Description: LFO generator and shaper - MIDI editor version
  *              Draw fancy LFO curves in REAPER's piano roll.
  * Instructions:  

--- a/MIDI Editor/js_Notation - Select all notes that have customized display lengths or positions.lua
+++ b/MIDI Editor/js_Notation - Select all notes that have customized display lengths or positions.lua
@@ -1,5 +1,5 @@
 --[[
-ReaScript Name: js_Notation - Select all notes that have customized display lengths or positions.lua
+ReaScript Name: Notation - Select all notes that have customized display lengths or positions
 Version: 1.0
 Author: juliansader
 Website: http://forum.cockos.com/showthread.php?t=172782&page=25

--- a/MIDI Editor/js_Notation - Set beaming of selected notes to custom rhythm.lua
+++ b/MIDI Editor/js_Notation - Set beaming of selected notes to custom rhythm.lua
@@ -1,5 +1,5 @@
 --[[
-ReaScript name: js_Notation - Set beaming of selected notes to custom rhythm (using grid as margin).lua
+ReaScript name: Notation - Set beaming of selected notes to custom rhythm (using grid as margin)
 Version: 1.01
 Author: juliansader
 Website: http://forum.cockos.com/showthread.php?t=172782&page=25

--- a/MIDI Editor/js_Notation - Set display length of selected notes to double and add staccato articulation.lua
+++ b/MIDI Editor/js_Notation - Set display length of selected notes to double and add staccato articulation.lua
@@ -1,5 +1,5 @@
 --[[
-ReaScript name: js_Notation - Set display length of selected notes to double and add staccato articulation.lua
+ReaScript name: Notation - Set display length of selected notes to double and add staccato articulation
 Version: 1.2
 Author: juliansader
 Website: http://forum.cockos.com/showthread.php?t=172782&page=25

--- a/MIDI Editor/js_Notation - Set display length of selected notes to quadruple and add staccatissimo articulation.lua
+++ b/MIDI Editor/js_Notation - Set display length of selected notes to quadruple and add staccatissimo articulation.lua
@@ -1,5 +1,5 @@
 --[[
-ReaScript name: js_Notation - Set display length of selected notes to quadruple and add staccatissimo articulation.lua
+ReaScript name: Notation - Set display length of selected notes to quadruple and add staccatissimo articulation
 Version: 1.2
 Author: juliansader
 Website: http://forum.cockos.com/showthread.php?t=172782&page=25

--- a/MIDI Editor/js_Notation - Set displayed length of selected notes to custom value.lua
+++ b/MIDI Editor/js_Notation - Set displayed length of selected notes to custom value.lua
@@ -1,5 +1,5 @@
 --[[
-ReaScript name: js_Notation - Set displayed length of selected notes to custom value.lua
+ReaScript name: Notation - Set displayed length of selected notes to custom value
 Version: 1.21
 Author: juliansader
 Website: http://forum.cockos.com/showthread.php?t=172782&page=25

--- a/MIDI Editor/js_Option - Selecting single note or CC in active take sets channel for new events.lua
+++ b/MIDI Editor/js_Option - Selecting single note or CC in active take sets channel for new events.lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name:  js_Option - Selecting single note or CC in active take sets channel for new events.lua
+ * ReaScript Name:  Option - Selecting single note or CC in active take sets channel for new events
  * Description: Inserting events in the wrong channel is an all-too-easy mistake to make, particularly after 
  *                  switching the active track. With this new option, the user can switch to the correct 
  *                  channel by simply clicking a note or CC of the new track. 

--- a/MIDI Editor/js_Option - Switching active take sets channel for new events to channel of existing events.lua
+++ b/MIDI Editor/js_Option - Switching active take sets channel for new events to channel of existing events.lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name:  js_Option - Switching active take sets channel for new events to channel of existing events.lua
+ * ReaScript Name:  Option - Switching active take sets channel for new events to channel of existing events
  * Description: Inserting events in the wrong MIDI channel is an all-too-easy mistake to make, particularly after 
  *                  switching the active track. If this option is activated, the default MIDI channel for new events  
  *                  will automatically be set to the channel of existing MIDI events in the newly active track, 

--- a/MIDI Editor/js_Remove redundant CCs (from selected events in lane under mouse).lua
+++ b/MIDI Editor/js_Remove redundant CCs (from selected events in lane under mouse).lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name:  js_Remove redundant CCs (from selected events in lane under mouse).lua
+ * ReaScript Name:  Remove redundant CCs (from selected events in lane under mouse)
  * Description:  Remove redundant events from 7-bit CC, pitchwheel or channel pressure lanes with a single click.
  * Instructions:  In the USER AREA of the script (below the changelog), the user can customize the following options:
  *                (It may be useful to link different versions of the script to different shortcuts.)

--- a/MIDI Editor/js_Run the js_'lane under mouse' script that is selected in toolbar (link this to shortcut and mousewheel).lua
+++ b/MIDI Editor/js_Run the js_'lane under mouse' script that is selected in toolbar (link this to shortcut and mousewheel).lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name: js_Run the js_'lane under mouse' script that is selected in toolbar (link this script to shortcut and mousewheel).lua
+ * ReaScript Name: Run the js_'lane under mouse' script that is selected in toolbar (link this script to shortcut and mousewheel)
  * Description: This script helps to improve the UI by allowing js_ MIDI editing functions to be selected via toolbar buttons, 
  *                  similar to FL Studio and other DAWs.
  *              Any js_ script that edits the 'lane under mouse' and that has been linked to a toolbar button can be 

--- a/MIDI Editor/js_Select and deselect MIDI notes by step pattern.lua
+++ b/MIDI Editor/js_Select and deselect MIDI notes by step pattern.lua
@@ -1,5 +1,5 @@
 --[[
-ReaScript name: js_Select and deselect MIDI notes by step pattern.lua
+ReaScript name: Select and deselect MIDI notes by step pattern
 Version: 0.95
 Author: juliansader
 Website: http://forum.cockos.com/showthread.php?t=176878

--- a/MIDI Editor/js_Split notes by drawing a line with the mouse.lua
+++ b/MIDI Editor/js_Split notes by drawing a line with the mouse.lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name:  js_Split notes by drawing a line with the mouse.lua
+ * ReaScript Name:  Split notes by drawing a line with the mouse
  * Description:  Split (slice) multiple notes by drawing a "cutting line" with the mouse in the MIDI editor piano roll.
  *               Notes that intersect the cutting line will be split at the position of intersection.
  *               If snap-to-grid is enabled in the MIDI editor, the notes will be split at the grid.

--- a/MIDI Editor/js_Split selected notes by drawing a line with the mouse.lua
+++ b/MIDI Editor/js_Split selected notes by drawing a line with the mouse.lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name:  js_Split selected notes by drawing a line with the mouse.lua
+ * ReaScript Name:  Split selected notes by drawing a line with the mouse
  * Description:  Split (slice) multiple selected notes by drawing a "cutting line" with the mouse in the MIDI editor piano roll.
  *               Notes that intersect the cutting line will be split at the position of intersection.
  *               If snap-to-grid is enabled in the MIDI editor, the notes will be split at the grid.

--- a/MIDI Editor/js_Stretch selected events in lane under mouse.lua
+++ b/MIDI Editor/js_Stretch selected events in lane under mouse.lua
@@ -1,5 +1,5 @@
 --[[
-ReaScript name:  js_Stretch selected events in lane under mouse.lua
+ReaScript name:  Stretch selected events in lane under mouse
 Version: 2.10
 Author: juliansader
 Screenshot: http://stash.reaper.fm/27594/Stretch%20selected%20events%20in%20lane%20under%20mouse%20-%20Copy.gif

--- a/MIDI Editor/js_Tilt selected CCs or velocities to mouse position.lua
+++ b/MIDI Editor/js_Tilt selected CCs or velocities to mouse position.lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name:  js_Tilt selected CCs or velocities to mouse position.lua
+ * ReaScript Name:  Tilt selected CCs or velocities to mouse position
  * Description:  A simple script for linear tilting of selected events in the lane under mouse.  
  *               The endpoint events are tilted to the exact value of the mouse position,
  *                  so the script is useful for precise positioning of ramps and other CC shapes.

--- a/MIDI Editor/js_Trim notes by drawing a line with the mouse.lua
+++ b/MIDI Editor/js_Trim notes by drawing a line with the mouse.lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name:  js_Trim notes by drawing a line with the mouse.lua
+ * ReaScript Name:  Trim notes by drawing a line with the mouse
  * Description:  Trims multiple notes by drawing a "cutting line" with the mouse in the MIDI editor piano roll.
  *               Notes that intersect the cutting line will be trimmed at the position of intersection.
  *               If snap-to-grid is enabled in the MIDI editor, the notes will be trimmed at the grid.

--- a/MIDI Editor/js_Trim selected notes by drawing a line with the mouse.lua
+++ b/MIDI Editor/js_Trim selected notes by drawing a line with the mouse.lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name:  js_Trim selected notes by drawing a line with the mouse.lua
+ * ReaScript Name:  Trim selected notes by drawing a line with the mouse
  * Description:  Trims multiple selected notes by drawing a "cutting line" with the mouse in the MIDI editor piano roll.
  *               Notes that intersect the cutting line will be trimmed at the position of intersection.
  *               If snap-to-grid is enabled in the MIDI editor, the notes will be trimmed at the grid.

--- a/MIDI Editor/js_Zoom MIDI editor to 5 measures at mouse position.lua
+++ b/MIDI Editor/js_Zoom MIDI editor to 5 measures at mouse position.lua
@@ -1,5 +1,5 @@
 --[[
-ReaScript name: js_Zoom MIDI editor to 5 measures at mouse position.lua
+ReaScript name: Zoom MIDI editor to 5 measures at mouse position
 Version: 1.10
 Author: juliansader
 Website:

--- a/Tracks Properties/js_Autoincrement MIDI send channels of selected tracks.lua
+++ b/Tracks Properties/js_Autoincrement MIDI send channels of selected tracks.lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name:  js_Autoincrement MIDI send channels of selected tracks
+ * ReaScript Name:  Autoincrement MIDI send channels of selected tracks
  * Description:  Autoincrements the MIDI send channels of selected tracks.
  *               Particularly useful when opening large MIDI files, to ensure that each track's MIDI is 1) sent to a 
  *                  single channel, and 2) sent to a different channel than other tracks' MIDI.

--- a/Tracks Properties/js_Propagate note names of last clicked track to all selected tracks.lua
+++ b/Tracks Properties/js_Propagate note names of last clicked track to all selected tracks.lua
@@ -1,5 +1,5 @@
 --[[
-ReaScript name: js_Propagate note names of last clicked track to all selected tracks.lua
+ReaScript name: Propagate note names of last clicked track to all selected tracks
 Version: 1.00
 Author: juliansader
 Website: http://forum.cockos.com/showthread.php?t=181276

--- a/Tracks Properties/js_Set MIDI send channel of selected tracks to channel of existing MIDI events in track.lua
+++ b/Tracks Properties/js_Set MIDI send channel of selected tracks to channel of existing MIDI events in track.lua
@@ -1,5 +1,5 @@
 --[[
- * ReaScript Name:  js_Set MIDI send channel of selected tracks to channel of existing MIDI events in track.lua
+ * ReaScript Name:  Set MIDI send channel of selected tracks to channel of existing MIDI events in track
  * Description:  Sets MIDI send channel of selected tracks to channel of existing MIDI events in track.
  *               Particularly useful when opening large MIDI files, to ensure that each track's MIDI is 1) sent to a 
  *                  single channel, and 2) sent to a different channel than other tracks' MIDI.


### PR DESCRIPTION
Removing the author prefix and file extension from the descriptions (and `reascript name` alias) to prettify the package list.

Ping @juliansader, just to be sure this change is alright with you.