### PR TITLE
Fixed issue with shortcuts highlighting the wrong menu.

### DIFF
--- a/Various/Lokasenna_Radial Menu.lua
+++ b/Various/Lokasenna_Radial Menu.lua
@@ -6123,7 +6123,7 @@ local function check_bind()
 
 			k = k >= 0 and (k - 1) or k
 
-			bound_mnu = {k - 1, reaper.time_precise(), mnu_arr[cur_depth][k] and mnu_arr[cur_depth][k].act or ""}
+			bound_mnu = {k, reaper.time_precise(), mnu_arr[cur_depth][k] and mnu_arr[cur_depth][k].act or ""}
 
 			--GUI.Msg("detect key bind: "..char.." -> act = "..table.concat(bound_mnu, ", "))
 


### PR DESCRIPTION
Using keyboard shortcuts would highlight the wrong menu. This fixes that behaviour.