### PR TITLE
Release Interactive ReaScript (iReaScript) v0.8.3

### DIFF
--- a/Development/cfillion_Interactive ReaScript.lua
+++ b/Development/cfillion_Interactive ReaScript.lua
@@ -3,7 +3,7 @@
 -- @version 0.8.3
 -- @changelog
 --   Fix blinking caret
---   Fix initial blank window on macOS and REAPER < 6
+--   Fix initial blank window on macOS and REAPER 5
 -- @link
 --   cfillion.ca https://cfillion.ca
 --   Forum Thread https://forum.cockos.com/showthread.php?t=177324

--- a/Development/cfillion_Interactive ReaScript.lua
+++ b/Development/cfillion_Interactive ReaScript.lua
@@ -4,6 +4,7 @@
 -- @changelog
 --   Fix blinking caret
 --   Fix initial blank window on macOS and REAPER 5
+--   Print the command name when running actions (SWS v2.10+ only)
 -- @link
 --   cfillion.ca https://cfillion.ca
 --   Forum Thread https://forum.cockos.com/showthread.php?t=177324

--- a/Development/cfillion_Interactive ReaScript.lua
+++ b/Development/cfillion_Interactive ReaScript.lua
@@ -1,12 +1,14 @@
 -- @description Interactive ReaScript (iReaScript)
--- @version 0.8.2
 -- @author cfillion
--- @changelog Use the default monospace font on Linux and Menlo on macOS.
--- @links
+-- @version 0.8.3
+-- @changelog
+--   Fix blinking caret
+--   Fix initial blank window on macOS and REAPER < 6
+-- @link
 --   cfillion.ca https://cfillion.ca
 --   Forum Thread https://forum.cockos.com/showthread.php?t=177324
--- @donation https://www.paypal.me/cfillion
 -- @screenshot https://i.imgur.com/RrGfulR.gif
+-- @donation https://www.paypal.me/cfillion
 -- @about
 --   # Interactive ReaScript (iReaScript)
 --
@@ -93,7 +95,7 @@ local ireascript = {
   -- settings
   TITLE = 'Interactive ReaScript (iReaScript)',
   NAME = 'Interactive ReaScript',
-  VERSION = '0.8.2',
+  VERSION = '0.8.3',
 
   MARGIN = 3,
   MAXLINES = 2048,
@@ -279,6 +281,7 @@ function ireascript.run()
   ireascript.history = {}
   ireascript.hindex = 0
   ireascript.lastMove = os.time()
+  ireascript.lastRedraw = os.time()
   ireascript.mouseCap = 0
   ireascript.selection = nil
   ireascript.lastClick = 0.0
@@ -743,6 +746,13 @@ function ireascript.loop()
     ireascript.update()
   end
 
+  local now = os.time()
+  if now - ireascript.lastRedraw >= 1 then
+    -- let the cursor caret blink
+    ireascript.redraw = true
+    ireascript.lastRedraw = now
+  end
+
   if ireascript.redraw then
     ireascript.redraw = false
     ireascript.draw()
@@ -1033,16 +1043,21 @@ function ireascript.execAction(name)
     name, midi = name:sub(2), true
   end
 
-  local id = reaper.NamedCommandLookup(name)
+  local id, section = reaper.NamedCommandLookup(name), 0
 
   if id > 0 then
     if midi then
       reaper.MIDIEditor_LastFocused_OnCommand(id, false)
+      section = 32060
     else
       reaper.Main_OnCommand(id, 0)
     end
 
     ireascript.format(id)
+    if reaper.CF_GetCommandText then -- SWS v2.10+
+      ireascript.push('\x20')
+      ireascript.format(reaper.CF_GetCommandText(section, id))
+    end
     ireascript.nl()
   else
     ireascript.errorFormat()
@@ -1769,6 +1784,12 @@ end
 
 -- GO!!
 ireascript.try(ireascript.run)
+
+-- since some v5.XX update the first frame is blank on macOS
+-- this got fixed v6.0rc9: https://forum.cockos.com/showthread.php?t=227788
+if not reaper.reduce_open_files then -- REAPER < 6
+  reaper.defer(ireascript.draw)
+end
 
 reaper.atexit(function()
   ireascript.saveWindowState()


### PR DESCRIPTION
Fix blinking caret
Fix initial blank window on macOS and REAPER 5
Print the command name when running actions (SWS v2.10+ only)