### PR TITLE
Release Set project grid (via dropdown menu) v1.03

### DIFF
--- a/Project Properties/amagalma_Set project grid (via dropdown menu).lua
+++ b/Project Properties/amagalma_Set project grid (via dropdown menu).lua
@@ -1,7 +1,9 @@
 -- @description Set project grid (via dropdown menu)
 -- @author amagalma
--- @version 1.01
--- @changelog Fix menu placement for OSX
+-- @version 1.03
+-- @changelog
+--   - Changed menu order to a more practical one
+--   - "Use the same grid division in arrange view and MIDI editor" setting is shown in menu header ("arrange" or "project")
 -- @link https://forum.cockos.com/showthread.php?t=239556
 -- @donation https://www.paypal.com/paypalme/amagalma
 -- @about
@@ -24,34 +26,37 @@ local m =
 {
   {1, "1/1    -  whole note"},
   {-1/2, ">1/2    -  half note"},
-  {3/4, "3/4  -  dotted half note"},
   {1/2, "1/2  -  half note"},
-  {1/3, "<1/3  -  half note triplet"},
+  {1/3, "1/3  -  half note triplet"},
+  {3/4, "<3/4  -  dotted half note"},
   {-1/4, ">1/4    -  quarter note"},
-  {3/8, "3/8  -  dotted quarter note"},
   {1/4, "1/4  -  quarter note"},
-  {1/6, "<1/6  -  quarter note triplet"},
+  {1/6, "1/6  -  quarter note triplet"},
+  {3/8, "<3/8  -  dotted quarter note"},
   {-1/8, ">1/8    -  eighth note"},
-  {3/16, "3/16  -  dotted eighth note"},
   {1/8, "1/8    -  eighth note"},
-  {1/12, "<1/12  -  eighth note triplet"},
+  {1/12, "1/12  -  eighth note triplet"},
+  {3/16, "<3/16  -  dotted eighth note"},
   {-1/16, ">1/16  -  sixteenth note"},
-  {3/32, "3/32  -  dotted sixteenth note"},
   {1/16, "1/16  -  sixteenth note"},
-  {1/24, "<1/24  -  sixteenth note triplet"},
+  {1/24, "1/24  -  sixteenth note triplet"},
+  {3/32, "<3/32  -  dotted sixteenth note"},
   {-1/32, ">1/32  -  thirty-second note"},
-  {3/64, "3/64  -  dotted thirty-second note"},
   {1/32, "1/32  -  thirty-second note"},
-  {1/48, "<1/48  -  thirty-second note triplet"},
+  {1/48, "1/48  -  thirty-second note triplet"},
+  {3/64, "<3/64  -  dotted thirty-second note"},
   {-1/64, ">1/64  -  sixty-fourth note"},
-  {3/128, "3/128  -  dotted sixty-fourth note"},
   {1/64, "1/64    -  sixty-fourth note"},
-  {1/96, "<1/96    -  sixty-fourth note triplet"}
+  {1/96, "1/96    -  sixty-fourth note triplet"},
+  {3/128, "<3/128  -  dotted sixty-fourth note"},
 }
 
 local _, division = reaper.GetSetProjectGrid( 0, 0, 0, 0, 0 )
+-- check if Use the same grid division in arrange view and MIDI editor
+local mode = reaper.GetToggleCommandState( 42010 )
+mode = mode == 0 and "arrange" or "project"
 
-local menu = "#Set grid to :||"
+local menu = "#Set " .. mode .. " grid to :||"
 for i = 1, #m do
   local togglestate
   if m[i][1] < 0 then


### PR DESCRIPTION
- Changed menu order to a more practical one
- "Use the same grid division in arrange view and MIDI editor" setting is shown in menu header ("arrange" or "project")