### PR TITLE
Release amagalma_gianfini_Track-Item Name Manipulation - UNDO v2.90

### DIFF
--- a/Various/amagalma_Track-Item Name Manipulation Replace Help.lua
+++ b/Various/amagalma_Track-Item Name Manipulation Replace Help.lua
@@ -1,9 +1,4 @@
--- @description amagalma_Track-Item Name Manipulation Replace Help
--- @author amagalma
--- @version 1.03
--- @about
---   # companion to "amagalma_gianfini_Track-Item Name Manipulation - UNDO" v2.7+
--- @noindex true
+-- @noindex
 
 local reaper = reaper
 local change = false


### PR DESCRIPTION
amagalma changes:
- Track manager is refreshed if open and track names changed (requires SWS and "Mirror track selection" option enabled
- add: You can now specify the number of digits when numbering