### PR TITLE
Fix Lokasenna_Create folder to contain selected tracks.lua

### DIFF
--- a/Tracks Properties/Lokasenna_Create folder to contain selected tracks.lua
+++ b/Tracks Properties/Lokasenna_Create folder to contain selected tracks.lua
@@ -41,7 +41,7 @@ reaper.SetMediaTrackInfo_Value( parent, "I_FOLDERDEPTH", 1, true )
 local lastSel = reaper.GetSelectedTrack(0, reaper.CountSelectedTracks(0) - 1)
 
 local curDepth = reaper.GetMediaTrackInfo_Value( lastSel, "I_FOLDERDEPTH" )
-local newDepth = (curDepth == 0) and (curDepth - 1) or -1
+local newDepth = curDepth - 1
 
 reaper.SetMediaTrackInfo_Value( lastSel, "I_FOLDERDEPTH", newDepth, true )
 

--- a/Tracks Properties/Lokasenna_Create folder to contain selected tracks.lua
+++ b/Tracks Properties/Lokasenna_Create folder to contain selected tracks.lua
@@ -1,10 +1,13 @@
 --[[
 Description: Create folder to contain selected tracks
-Version: 1.0.0
+Version: 1.1.0
 Author: Lokasenna
 Donation: https://paypal.me/Lokasenna
 Changelog:
-	Initial release
+* v1.0.0
+   + Initial release
+* v1.1.0 (2020-12-23)
+  + Fix folder creating when last selected track is last in folder or a folder itself.
 Links:
 	Lokasenna's Website http://forum.cockos.com/member.php?u=10417
 About:
@@ -40,10 +43,17 @@ reaper.SetMediaTrackInfo_Value( parent, "I_FOLDERDEPTH", 1, true )
 
 local lastSel = reaper.GetSelectedTrack(0, reaper.CountSelectedTracks(0) - 1)
 
-local curDepth = reaper.GetMediaTrackInfo_Value( lastSel, "I_FOLDERDEPTH" )
-local newDepth = curDepth - 1
-
-reaper.SetMediaTrackInfo_Value( lastSel, "I_FOLDERDEPTH", newDepth, true )
+local lastSelIdx = reaper.GetMediaTrackInfo_Value(lastSel, "IP_TRACKNUMBER") - 1
+local curDepth = 0
+for trackIdx = lastSelIdx, reaper.CountTracks(0) - 1 do
+    local track = reaper.GetTrack(0, trackIdx)
+    local trackDepth = reaper.GetMediaTrackInfo_Value( track, "I_FOLDERDEPTH" )
+    curDepth = curDepth + trackDepth
+    if curDepth <= 0 then
+        reaper.SetMediaTrackInfo_Value( track, "I_FOLDERDEPTH", trackDepth - 1, true )
+        break
+    end
+end
 
 reaper.PreventUIRefresh( -1 )
 

--- a/Tracks Properties/Lokasenna_Create folder to contain selected tracks.lua
+++ b/Tracks Properties/Lokasenna_Create folder to contain selected tracks.lua
@@ -3,13 +3,8 @@ Description: Create folder to contain selected tracks
 Version: 1.1.0
 Author: Lokasenna
 Donation: https://paypal.me/Lokasenna
-Changelog:
-* v1.0.0
-   + Initial release
-* v1.1.0 (2020-12-23)
-  + Fix folder creating when last selected track is last in folder or a folder itself.
-Links:
-	Lokasenna's Website http://forum.cockos.com/member.php?u=10417
+Changelog: Fix folder creating when last selected track is last in folder or a folder itself.
+Links: Lokasenna's Website http://forum.cockos.com/member.php?u=10417
 About:
   Creates a new track to serve as a folder parent for the selected tracks,
   prompting the user for a name. The selected tracks must be contiguous and at


### PR DESCRIPTION
[The current implementation includes the following line](https://github.com/ReaTeam/ReaScripts/blob/7c05f6416cc0625117250cda6264d77053daf321/Tracks%20Properties/Lokasenna_Create%20folder%20to%20contain%20selected%20tracks.lua#L44):

```lua
local newDepth = (curDepth == 0) and (curDepth - 1) or -1
```

This line doesn’t make sense, because if `curDepth == 0` holds, then `curDepth - 1` is `-1`, so `newDepth` is always `-1`.

I believe the intent is to say `newDepth = curDepth - 1`, which means the that the `lastSel` is now the last track of yet another folder (the one we just created).

With this fix, the action behaves more sanely when creating folders within folders. Consider the following example:

```
TRACK 1
  TRACK 2 (SELECTED)
  TRACK 3 (SELECTED)
TRACK 4
```

In the current implementation the result would be:

```
TRACK 1
  TRACK NEW
    TRACK 2 (SELECTED)
    TRACK 3 (SELECTED)
  TRACK 4
```

But with my fix the result is:

```
TRACK 1
  TRACK NEW
    TRACK 2 (SELECTED)
    TRACK 3 (SELECTED)
TRACK 4
```

Note how `TRACK 4` hasn’t been nested into `TRACK 1`.

There’s still (both in the original version as well as in my fixed version) an inconvenience when the last selected track is itself a folder, for example:

```
TRACK 1 (SELECTED)
TRACK 2 (SELECTED)
  TRACK 3
```

Which results in:

```
TRACK NEW
  TRACK 1 (SELECTED)
  TRACK 2 (SELECTED)
TRACK 3
```

Note how `TRACK 2` is no longer a parent of `TRACK 3`.

But fixing this would require traversing `TRACK 3` onward looking for the last child. This would complicate the action beyond its scope (I think, if you disagree let me know and I can try to come up with a pull request). One can always select `TRACK 3` as well and then it works.