### PR TITLE
Release Preset velocity v0.2

### DIFF
--- a/MIDI Editor/kl_Preset velocity/Note Preview.jsfx
+++ b/MIDI Editor/kl_Preset velocity/Note Preview.jsfx
@@ -1,6 +1,8 @@
 noindex: true
 
-version: 0.1
+noindex: true
+
+version: 0.2
 author: KL
 # Preset Velocity
 desc: Note Preview
@@ -13,7 +15,7 @@ options:gmem=ddddddddddddddddddsgd334f3e_____________________gh
 @block
 
 while (midirecv(offset,msg1,msg2,msg3)) (
-    (play_state==0)&&(msg1&$xF0==$x90)?(
+    (play_state==0)&&(msg1&$xF0==$x90)&&(msg3!==0)?(
       midisend(offset, msg1,msg2, gmem[0]); ):(midisend(offset, msg1,msg2,msg3);
  );
 );


### PR DESCRIPTION
-- CHANGELOG  ( changelog )  Version 0.2
-- 2-25-2021 - Excessive defer calls have been replaced with tail calls. Script is now faster.
-  Eliminated excessive calls to update()
-  Note Preview.jsfx :  velocity 0 "noteoffs" no longer passes as note ons to cause trouble.