### PR TITLE
Release Color palette v1.51

### DIFF
--- a/Various/rodilab_Color palette.lua
+++ b/Various/rodilab_Color palette.lua
@@ -1,6 +1,6 @@
 -- @description Color palette
 -- @author Rodilab
--- @version 1.51
+-- @version 1.5.1
 -- @changelog
 --   - Track Manager and Region/Marker Manager work on all OS
 --   - Ctrl+Alt-click (Ctrl-click on Mac) with 'Takes' target set color to all takes (active, and non actives)


### PR DESCRIPTION
- Track Manager and Region/Marker Manager work on all OS
- Ctrl+Alt-click (Ctrl-click on Mac) with 'Takes' target set color to all takes (active, and non actives)
- Highlight border is black if color is very light
- Improved "Set 1st user to default tracks" option
- Improved "Track Manager and Region / Marker Manager" detection