### PR TITLE
Release Track name groups v1.30

### DIFF
--- a/Tracks Properties/rodilab_Track name groups.lua
+++ b/Tracks Properties/rodilab_Track name groups.lua
@@ -2,6 +2,7 @@
 -- @author Rodilab
 -- @version 1.30
 -- @changelog
+--   - Double click on tag button to vertical zoom on tracks
 --   - New "Track name [Start with / Contains] name" option in settings
 --   - New insert multiple tracks feature
 --   - "Insert new tracks" can be done on tags that do not exist yet


### PR DESCRIPTION
- New "Track name [Start with / Contains] name" option in settings
- New insert multiple tracks feature
- "Insert new tracks" can be done on tags that do not exist yet
- Remplace "Solo (ignore routing)" with "Solo in place"
- Fix solo button behavior
- Fix undo block bug