### PR TITLE
Release Restore tracks floating fx windows (4 slots) v1.01

### DIFF
--- a/FX/edgemeal_Restore tracks floating fx windows (4 slots).lua
+++ b/FX/edgemeal_Restore tracks floating fx windows (4 slots).lua
@@ -1,14 +1,16 @@
 -- @description Restore tracks floating fx windows (4 slots)
 -- @author Edgemeal
--- @version 1.00
--- @link Forum https://forum.cockos.com/showpost.php?p=2349852&postcount=2196
--- @donation Donate https://www.paypal.me/Edgemeal
--- @metapackage
+-- @version 1.01
+-- @changelog When restoring a slot and the floating fx window is already open then it is closed to act like a toggle.
 -- @provides
+--   .
 --   [main] . > edgemeal_Restore tracks floating fx windows from slot 1.lua
 --   [main] . > edgemeal_Restore tracks floating fx windows from slot 2.lua
 --   [main] . > edgemeal_Restore tracks floating fx windows from slot 3.lua
 --   [main] . > edgemeal_Restore tracks floating fx windows from slot 4.lua
+-- @link Forum https://forum.cockos.com/showpost.php?p=2349852&postcount=2196
+-- @donation Donate https://www.paypal.me/Edgemeal
+-- @about For use with,  Save selected tracks floating fx windows (4 slots)
 
 local track_count = reaper.CountTracks(0)
 
@@ -18,7 +20,12 @@ function ShowFx(guid)
     local track_fx_count = reaper.TrackFX_GetCount(track)
     for j = 0, track_fx_count-1 do
       if reaper.TrackFX_GetFXGUID(track, j) == guid then
-        reaper.TrackFX_Show(track, j, 3)
+	      local hwnd = reaper.TrackFX_GetFloatingWindow(track, j)
+        if hwnd == nil then
+          reaper.TrackFX_Show(track, j, 3) -- show floating window
+        else
+          reaper.TrackFX_Show(track, j, 2) -- hide floating window
+        end
         return
       end
     end


### PR DESCRIPTION
When restoring a slot and the floating fx window is already open then it is closed to act like a toggle.