### PR TITLE
Release Smart split items by mouse cursor v2.2

### DIFF
--- a/Items Editing/az_Smart split items by mouse cursor.lua
+++ b/Items Editing/az_Smart split items by mouse cursor.lua
@@ -374,6 +374,9 @@ end
 
 
 --CONTEXT DEFINING CODE--
+version = reaper.GetExtState("SmartSplit_AZ", "version")
+if version ~= "2.2" then reaper.SetExtState("SmartSplit_AZ", "version", "2.2", true) end
+    
 window, segment, details = reaper.BR_GetMouseCursorContext()
 
 if RazorEditSelectionExists()==true then


### PR DESCRIPTION
Removed dead zone where mouse placed on envelope and no automation item selected.
For now it provides as empty arrange zone, and items should splitted at edit cursor or time selection.