### PR TITLE
Release Limit items edges at source start and stop v1.1

### DIFF
--- a/Items Editing/rodilab_Limit items edges at source start and stop.lua
+++ b/Items Editing/rodilab_Limit items edges at source start and stop.lua
@@ -1,12 +1,14 @@
 -- @description Limit items edges at source start and stop
 -- @author Rodilab
--- @version 1.0
+-- @version 1.1
+-- @changelog
+--   This version works in a very different way.
+--   Now works with crossfades, double adjacent edges and "move item contents".
 -- @about
 --   This is a togglable defer script.
---   As long is activate : dragging the items edges can't expand audio items beyond source media start and end.
+--   As long is enable : dragging items edges can't expand audio items beyond source media start and end.
 --
 --   Requirement :
---   - SWS Extension
 --   - js_ReaScriptAPI: API functions
 --
 --   by Rodrigo Diaz (aka Rodilab)
@@ -14,100 +16,60 @@
 ---------------------------------------
 -- Debug
 ---------------------------------------
+
 function Debug()
-  local debug = false
-  local debug_str = ''
-  if reaper.APIExists('CF_GetSWSVersion') == false then
-    debug_str = "\"SWS extension\" : https://www.sws-extension.org\n"
-    debug = true
-  end
-  if reaper.APIExists('JS_ReaScriptAPI_Version') == false then
-    local ReaPack_exist = reaper.APIExists('ReaPack_BrowsePackages')
-    if ReaPack_exist == true then
+  if reaper.APIExists('JS_ReaScriptAPI_Version') then
+    return true
+  else
+    if reaper.APIExists('ReaPack_BrowsePackages') then
       reaper.ReaPack_BrowsePackages('js_ReaScriptAPI: API functions for ReaScripts')
     end
-    debug_str = debug_str.."\"js_ReaScriptAPI: API functions for ReaScripts\" with ReaPack and restart Reaper\n"
-    debug = true
-  end
-  if debug then
-    reaper.ShowMessageBox('Please install :\n'..debug_str, 'Error', 0)
+    reaper.ShowMessageBox('Please install \"js_ReaScriptAPI: API functions for ReaScripts\" and restart Reaper', 'Error', 0)
     return false
-  else
-    return true
   end
 end
 
 ---------------------------------------
 -- Global variables
 ---------------------------------------
+
+OS_Mac = string.match(reaper.GetOS(),"OSX")
 is_clicking = false
-item, is_edge = nil
 last_left_click = 0
-item_list, edge_pos_list = {}
+local reaper_cursors = {
+                        {417,'EDGE L'},
+                        {418,'EDGE R'},
+                        {450,'EDGE DOUBLE'},
+                        {105,'FADE L'},
+                        {184,'FADE R'},
+                        {463,'FADE MOVE'},
+                        {528,'FADE LENGTH'},
+                        {465,'MOVE CONTENT'}
+                       }
 
 ---------------------------------------
 -- Functions
 ---------------------------------------
+
+function Msg(str)
+  reaper.ShowConsoleMsg(tostring(str)..'\n')
+end
+
 function ToggleThisScript(state)
   local is_new_value, filename, section_id, command_id = reaper.get_action_context()
   reaper.SetToggleCommandState(section_id, command_id, state)
   reaper.RefreshToolbar2(section_id, command_id)
 end
 
-function IsEdge(item)
-  local cursor_pos = reaper.BR_PositionAtMouseCursor(false)
-  local pos = reaper.GetMediaItemInfo_Value(item, 'D_POSITION')
-  local length = reaper.GetMediaItemInfo_Value(item, 'D_LENGTH')
-  local zoom = reaper.GetHZoomLevel()
-  if cursor_pos >= pos and cursor_pos <= (pos + 7/zoom) then
-    return 1
-  elseif cursor_pos <= pos+length and cursor_pos >= (pos+length)-8/zoom then
-    return 2
+function MouseCursor()
+  local cur_cursor = reaper.JS_Mouse_GetCursor()
+  for i = 1, #reaper_cursors do
+    local cursor = reaper.JS_Mouse_LoadCursor(reaper_cursors[i][1])
+    if cur_cursor == cursor then
+      return reaper_cursors[i][2]
+    end
   end
   return nil
-end
-
-function GetItemList(item)
-  local item_list = {}
-  local edge_pos_list = {}
-  if reaper.IsMediaItemSelected(item) then
-    local count = reaper.CountSelectedMediaItems(0)
-    for i=0, count-1 do
-      local item = reaper.GetSelectedMediaItem(0, i)
-      if reaper.GetMediaItemInfo_Value(item, 'B_LOOPSRC') == 0 then
-        table.insert(item_list, item)
-      end
-    end
-  else
-    if reaper.GetMediaItemInfo_Value(item, 'B_LOOPSRC') == 0 then
-      table.insert(item_list, item)
-    end
-  end
-  for i, item in ipairs(item_list) do
-    local pos = reaper.GetMediaItemInfo_Value(item, 'D_POSITION')
-    if is_edge == 1 then
-      table.insert(edge_pos_list, pos)
-    elseif is_edge == 2 then
-      length = reaper.GetMediaItemInfo_Value(item, 'D_LENGTH')
-      table.insert(edge_pos_list, pos+length)
-    end
-  end
-  return item_list, edge_pos_list
-end
-
-function GetGroupedItems(item)
-  local list = {}
-  local group = reaper.GetMediaItemInfo_Value(item, 'I_GROUPID')
-  if group > 0 then
-    local count = reaper.CountMediaItems(0)
-    for i=0, count-1 do
-      local group_item = reaper.GetMediaItem(0, i)
-      if group_item ~= item and group == reaper.GetMediaItemInfo_Value(group_item, 'I_GROUPID') then
-        table.insert(list, group_item)
-      end
-    end
-  end
-  return list
 end
 
 function TrimOversizedEdge(item, edge)
@@ -123,29 +85,133 @@ local take = reaper.GetActiveTake(item)
       local source_length, lengthIsQN = reaper.GetMediaSourceLength(source)
       if lengthIsQN == true then return end
       local source_length = source_length/playrate
-      local group_list = GetGroupedItems(item)
-      local cut
-      if edge == 1 and startoffs < 0 then
-        -- Trim left edge to cursor
-        cut = position-startoffs
-        local new_item = reaper.SplitMediaItem(item, cut)
-        reaper.DeleteTrackMediaItem(reaper.GetMediaItemTrack(item), item)
-      elseif edge == 2 and length+startoffs > source_length then
-        -- Trim right edge to cursor
-        cut = position-startoffs+source_length
-        local new_item = reaper.SplitMediaItem(item, cut)
-        reaper.DeleteTrackMediaItem(reaper.GetMediaItemTrack(new_item), new_item)
+      if (edge == 'left' or edge == 'content') and startoffs < 0 then
+        reaper.SetEditCurPos(position-startoffs, false, false)
+        reaper.SelectAllMediaItems(0, false)
+        reaper.SetMediaItemSelected(item, true)
+        reaper.Main_OnCommand(41305, 0) -- Item edit: Trim left edge of item to edit cursor
       end
-      if #group_list > 0 then
-        for i, item in ipairs(group_list) do
-          local new_item = reaper.SplitMediaItem(item, cut)
-          if edge == 1 then
-            reaper.DeleteTrackMediaItem(reaper.GetMediaItemTrack(item), item)
-          elseif edge == 2 then
-            reaper.DeleteTrackMediaItem(reaper.GetMediaItemTrack(new_item), new_item)
+      if (edge == 'right' or edge == 'content') and length+startoffs > source_length then
+        reaper.SetEditCurPos(position-startoffs+source_length, false, false)
+        reaper.SelectAllMediaItems(0, false)
+        reaper.SetMediaItemSelected(item, true)
+        reaper.Main_OnCommand(41311, 0) -- Item edit: Trim right edge of item to edit cursor
+      end
+    end
+  end
+end
+
+function GetSelectedItems()
+  local list = {}
+  local count = reaper.CountSelectedMediaItems(0)
+  if count > 0 then
+    for i=0, count-1 do
+      local item = reaper.GetSelectedMediaItem(0, i)
+      table.insert(list, item)
+    end
+  end
+  return list
+end
+
+function SelectListItems(list)
+  reaper.SelectAllMediaItems(0, false)
+  for i, item in ipairs(list) do
+    reaper.SetMediaItemSelected(item, true)
+  end
+end
+
+function GetAllItemsFromPoint(x, y, MC)
+  local rv, left, top = reaper.JS_Window_GetClientRect(reaper.JS_Window_FindChildByID(reaper.GetMainHwnd(), 1000))
+  if not rv then return end
+  local cur_pos = reaper.GetSet_ArrangeView2(0, false, x, x+1)
+  local track, info = reaper.GetTrackFromPoint(x, y)
+  if track and info == 0 then
+    local count = reaper.CountTrackMediaItems(track)
+    if count > 0 then
+      local track_y = reaper.GetMediaTrackInfo_Value(track, 'I_TCPY')
+      local y2
+      if OS_Mac then
+        y2 = top-y
+      else
+        y2 = y-top
+      end
+      local zoom = reaper.GetHZoomLevel()
+      local list = {}
+      local is_selected = false
+      for i=0, count-1 do
+        local match = false
+        local edge
+        local item = reaper.GetTrackMediaItem(track, i)
+        local pos = reaper.GetMediaItemInfo_Value(item, 'D_POSITION')
+        local length = reaper.GetMediaItemInfo_Value(item, 'D_LENGTH')
+        local fade_in =  reaper.GetMediaItemInfo_Value(item, 'D_FADEINLEN_AUTO')
+        local fade_out =  reaper.GetMediaItemInfo_Value(item, 'D_FADEOUTLEN_AUTO')
+        if pos-9/zoom > cur_pos then break end
+        if reaper.GetMediaItemInfo_Value(item, 'C_LOCK') == 0 then
+          if (MC == 'EDGE L' and cur_pos >= pos-4/zoom and cur_pos <= pos+8/zoom)
+          or (MC == 'FADE R' and fade_in  > 0 and cur_pos >= pos-8/zoom and cur_pos < pos+fade_in)
+          or (MC == 'EDGE DOUBLE' and cur_pos >= pos-4/zoom and cur_pos <= pos+4/zoom)
+          or ((MC == 'FADE MOVE' or MC == 'FADE LENGTH') and fade_in > 0 and cur_pos > pos and cur_pos < pos+fade_in) then
+            edge = 'left'
+          elseif (MC == 'EDGE R' and cur_pos >= pos+length-8/zoom and cur_pos <= pos+length+4/zoom)
+          or (MC == 'FADE L' and fade_out > 0 and cur_pos > pos+length-fade_out and cur_pos <= pos+length+8/zoom)
+          or (MC == 'EDGE DOUBLE' and cur_pos >= pos+length-4/zoom and cur_pos <= pos+length+4/zoom)
+          or ((MC == 'FADE MOVE' or MC == 'FADE LENGTH') and fade_out > 0 and cur_pos > pos+length-fade_out and cur_pos < pos+length) then
+            edge = 'right'
+          elseif MC == 'MOVE CONTENT' and cur_pos > pos and cur_pos < pos+length then
+            edge = 'content'
+          end
+          if edge then
+            lasty = reaper.GetMediaItemInfo_Value(item, 'I_LASTY')
+            lasth = reaper.GetMediaItemInfo_Value(item, 'I_LASTH')
+            if y2 >= track_y+lasty and y2 <= track_y+lasty+lasth then
+              if (MC == 'EDGE L' or MC == 'EDGE R' or MC == 'MOVE CONTENT') and not is_selected and reaper.IsMediaItemSelected(item) then
+                is_selected = true
+              end
+              local edge_pos
+              if edge == 'left' then
+                edge_pos = pos
+              elseif edge == 'right' then
+                edge_pos = pos+length
+              elseif edge == 'content' then
+                edge_pos = reaper.GetMediaItemTakeInfo_Value(reaper.GetActiveTake(item), 'D_STARTOFFS')
+              end
+              table.insert(list, {item, edge, edge_pos})
+            end
           end
         end
       end
+      if #list > 0 then
+        return true, list, is_selected
+      end
+    end
+  end
+  return false
+end
+
+function AddSelItems(MC)
+  local count = reaper.CountSelectedMediaItems(0)
+  local tmp_item_list = {}
+  for i=1, #item_list do
+    tmp_item_list[item_list[i][1]] = true
+  end
+  for i=0, count-1 do
+    local item = reaper.GetSelectedMediaItem(0, i)
+    if not tmp_item_list[item] then
+      local pos = reaper.GetMediaItemInfo_Value(item, 'D_POSITION')
+      local length = reaper.GetMediaItemInfo_Value(item, 'D_LENGTH')
+      local edge, edge_pos
+      if MC == 'EDGE L' then
+        edge = 'left'
+        edge_pos = pos
+      elseif MC == 'EDGE R' then
+        edge = 'right'
+        edge_pos = pos+length
+      elseif MC == 'MOVE CONTENT' then
+        edge = 'content'
+        edge_pos = reaper.GetMediaItemTakeInfo_Value(reaper.GetActiveTake(item), 'D_STARTOFFS')
+      end
+      table.insert(item_list, {item, edge, edge_pos})
     end
   end
 end
@@ -157,47 +223,43 @@ end)
 ---------------------------------------
 -- Main Loop
 ---------------------------------------
+
 function loop()
   local left_click = reaper.JS_Mouse_GetState(1)
   if not is_clicking and last_left_click == 0 and left_click == 1 then
     local x, y = reaper.GetMousePosition() 
     local rv, info = reaper.GetThingFromPoint(x, y)
     if rv and info == 'arrange' then
-      item = reaper.GetItemFromPoint(x, y, false)
-      if item then
-        is_edge = IsEdge(item)
-      else
-        item = reaper.GetItemFromPoint(x-4, y, false)
-        is_edge = 2
-        if not item then
-          item = reaper.GetItemFromPoint(x+4, y, false)
-          is_edge = 1
+      local track, info = reaper.GetTrackFromPoint(x, y)
+      if info == 0 then
+        local MC = MouseCursor()
+        if MC then
+          is_clicking, item_list, is_selected = GetAllItemsFromPoint(x, y, MC)
+          if is_selected then
+            AddSelItems(MC)
+          end
         end
-      end
-      if item and is_edge then
-        is_clicking = true
-        item_list, edge_pos_list = GetItemList(item)
-      else
-        item, is_edge = nil
-        item_list, edge_pos_list = {}
       end
     end
   elseif is_clicking and left_click == 0 then
     reaper.Undo_BeginBlock()
     reaper.PreventUIRefresh(1)
-    for i, item in ipairs(item_list) do
+    local selected_items = GetSelectedItems()
+    for i, list in ipairs(item_list) do
+      local item = list[1]
       local pos = reaper.GetMediaItemInfo_Value(item, 'D_POSITION')
       local length = reaper.GetMediaItemInfo_Value(item, 'D_LENGTH')
-      if (is_edge == 1 and pos ~= edge_pos_list[i]) or (is_edge == 2 and pos+length ~= edge_pos_list[i]) then
-        TrimOversizedEdge(item, is_edge)
+      if (list[2] == 'left'    and list[3] ~= pos)
+      or (list[2] == 'right'   and list[3] ~= pos+length)
+      or (list[2] == 'content' and list[3] ~= reaper.GetMediaItemTakeInfo_Value(reaper.GetActiveTake(item), 'D_STARTOFFS')) then
+        TrimOversizedEdge(item, list[2])
       end
     end
+    SelectListItems(selected_items)
     reaper.Undo_EndBlock("Limit items edges at source start and stop",0)
     reaper.PreventUIRefresh(-1)
     reaper.UpdateArrange()
     is_clicking = false
-    item, is_edge = nil
-    item_list, edge_pos_list = {}
   end
   last_left_click = left_click
   reaper.defer(loop)
@@ -206,6 +268,7 @@ end
 ---------------------------------------
 -- Start
 ---------------------------------------
+
 if Debug() then
   ToggleThisScript(1)
   reaper.defer(loop)


### PR DESCRIPTION
This version works in a very different way.
Now works with crossfades, double adjacent edges and "move item contents".