### PR TITLE
Fix non-English text in trim mode (amagalma_gianfini_ReaNamer) 

### DIFF
--- a/Various/amagalma_gianfini_ReaNamer (track-item-region renaming utility).lua
+++ b/Various/amagalma_gianfini_ReaNamer (track-item-region renaming utility).lua
@@ -99,6 +99,34 @@ function class(base, init)
    setmetatable(c, mt)
    return c
 end
+
+--/////////////////////////////////
+-- Helper for non-English string //
+--/////////////////////////////////
+local function strTable(s)
+    -- string to table array
+    local tb = {}
+        for utfChar in string.gmatch(s, "[%z\1-\127\194-\244][\128-\191]*") do
+            table.insert(tb, utfChar)
+        end
+    return tb
+end
+
+local function subalt(s, first, last)
+    -- string table array sub
+    tb = strTable(s)
+    if last == -1 then
+        last = #tb
+    end
+
+    local resultStr = ""
+    for i=1, #tb do
+        if i >= first and i <= last then
+            resultStr = resultStr .. tb[i]
+        end
+    end
+    return resultStr
+end
 ----------------------------------------------------------------------------------------
 
 local btn_DOWN_can_move, btn_height, win_border, win_double_vert_border, win_h, win_vert_border, win_w
@@ -952,17 +980,18 @@ function ApplyModifier(prevName, modifier, parm1, parm2, seq_number) -- apply on
   elseif modifier == "clear" then
     newName = ""
   elseif modifier == "trimstart" then
-    newName = newName:sub(parm1 + 1)
+    newName = subalt(newName, parm1 + 1, -1)
   elseif modifier == "trimend" then
-    local length = newName:len()
-    newName = newName:sub(1, length - parm1)
+    local length = #strTable(newName)
+    newName = subalt(newName, 1, length - parm1)
   elseif modifier == "keep" then
     local mode, number = parm1:match("([seSE])%s?(%d+)")
     number = tonumber(number)
     if mode:match("[sS]") then
-      newName = newName:sub(0, number)
+      newName = subalt(newName, 0, number)
     else
-      newName = newName:sub((-1)*number)
+      local length = #strTable(newName)
+      newName = subalt(newName, length - number + 1, -1)
     end
   elseif modifier == "replace" then
     if parm1 ~= "" then


### PR DESCRIPTION
## Issuse

Lua standard library string's function `sub` did not fit with non-English text.

The length of non-English text is 3. And English or number's length is 1.

So, `string.sub` will cause issues with non-English text.

## Changed

> No change compared to original if text is English or number.

I write some code call `Helper for non-English string` to fit with non-English text.

Diff url: https://github.com/wastee/ReaTeam-ReaScripts/commit/cad2101d6202fe7a73ca09f1471ac15382e6937c

## Result GIF

### test

![Trim Start 3](https://user-images.githubusercontent.com/22229962/147812767-69e1b798-840f-4f71-9f3b-9db319169d0c.png)
![Trim End 3](https://user-images.githubusercontent.com/22229962/147812773-a51bcfa6-6b76-4fe5-b73a-b580ac8ed0ca.png)

### result

![Peek 2021-12-31 16-32](https://user-images.githubusercontent.com/22229962/147812796-c13a7310-7ac1-4fb8-8d09-a477637e0c60.gif)

