### PR TITLE
ReaImGui v0.7+ compatibility

### DIFF
--- a/Items Properties/rodilab_Rename takes and item notes with BWF and iXML metadata.lua
+++ b/Items Properties/rodilab_Rename takes and item notes with BWF and iXML metadata.lua
@@ -1,7 +1,7 @@
 -- @description Rename takes and item notes with BWF and iXML metadata
 -- @author Rodilab
--- @version 2.0
--- @changelog New ReaImGui interface
+-- @version 2.0.1
+-- @changelog Enable ReaImGui backward-compatibility module
 -- @link Forum thread https://forum.cockos.com/showthread.php?t=250505
 -- @donation Donate via PayPal https://www.paypal.com/donate?hosted_button_id=N5DUAELFWX4DC
 -- @about
@@ -11,6 +11,9 @@
 --   $bitdepth, $chnl, $circled, $date, $falsestart, $fileindex, $filename, $filetyp, $nogood, $note, $originator, $originatorref, $project, $reaname, $reaproject, $reatrack, $samplerate, $scene, $speed, $startoffsset, $tag, $take, $taketyp, $tape, $tcstart, $time, $timeref, $totalfiles, $trackcount, $trackname, $ubits, $wildtrack
 --
 --   by Rodrigo Diaz (aka Rodilab)
+
+local imgui_compat = reaper.GetResourcePath() .. '/Scripts/ReaTeam Extensions/API/imgui.lua'
+if reaper.file_exists(imgui_compat) then dofile(imgui_compat)('0.6') end
 
 r = reaper
 script_name = 'Rename takes and item notes with BWF and iXML metadata'

--- a/Tracks Properties/rodilab_Track name groups.lua
+++ b/Tracks Properties/rodilab_Track name groups.lua
@@ -1,12 +1,7 @@
 -- @description Track name groups
 -- @author Rodilab
--- @version 1.41
--- @changelog
---   - "Auto-remove empty tags" option
---   - Fix multiple project tabs bug
---   - New key modifiers (right-click on buttons to more info)
---   - First right click give window focus
---   - Add "Track name ends with the tag" option
+-- @version 1.41.1
+-- @changelog Enable ReaImGui backward-compatibility module
 -- @link Forum thread https://forum.cockos.com/showthread.php?t=255223
 -- @donation Donate via PayPal https://www.paypal.com/donate?hosted_button_id=N5DUAELFWX4DC
 -- @about
@@ -21,6 +16,9 @@
 --   - Drag and drop name buttons to move tracks
 --   - Buttons are automatically reordered according to the order of the tracks in the session
 --   - Buttons take the color of first track found
+
+local imgui_compat = reaper.GetResourcePath() .. '/Scripts/ReaTeam Extensions/API/imgui.lua'
+if reaper.file_exists(imgui_compat) then dofile(imgui_compat)('0.6') end
 
 r = reaper
 script_name = 'Track name groups'

--- a/Various/rodilab_Color palette.lua
+++ b/Various/rodilab_Color palette.lua
@@ -1,9 +1,7 @@
 -- @description Color palette
 -- @author Rodilab
--- @version 2.10
--- @changelog
---   - Minor code improvement
---   - Fix popup window position
+-- @version 2.10.1
+-- @changelog ReaImGui v0.7 compatibility
 -- @provides
 --   [data] rodilab_Color palette/color_palette_arm.cur
 --   [data] rodilab_Color palette/color_palette_arm_insert.cur
@@ -61,6 +59,9 @@
 --   - Many settings...
 --
 --   by Rodrigo Diaz (aka Rodilab)
+
+local imgui_compat = reaper.GetResourcePath() .. '/Scripts/ReaTeam Extensions/API/imgui.lua'
+if reaper.file_exists(imgui_compat) then dofile(imgui_compat)('0.6') end
 
 r = reaper
 script_name = "Color palette"


### PR DESCRIPTION
ReaImGui v0.7 is currently set to have three breaking changes affecting these three scripts:

- Rename `KeyModFlags_*` constants to `ModFlags_*` [[p=2544651](https://forum.cockos.com/showpost.php?p=2544651)]
- `Combo` and `ListBox`: use NULL bytes for delimiting items as in vanilla Dear ImGui (requires REAPER 6.44+ in Lua and EEL)
- Remove color packing return value of `ColorConvertHSVtoRGB`

EDIT: v0.7 will ship with a new compatibility script allowing scripts to specify the API version they were written for.

```lua
dofile(reaper.GetResourcePath() .. '/Scripts/ReaTeam Extensions/API/imgui.lua')('0.6')
-- API is compatible with v0.6 from this point
```

Pinging @Rodilab for review.