### PR TITLE
Update BuyOne_Move selected FX envelope in track to top_bottom_upwards_downwards.lua

### DIFF
--- a/Envelopes/BuyOne_Move selected FX envelope in track to top_bottom_upwards_downwards.lua
+++ b/Envelopes/BuyOne_Move selected FX envelope in track to top_bottom_upwards_downwards.lua
@@ -26,7 +26,8 @@ About:  Moves selected FX envelope of a track to the top/bottom lane,
 	cannot be reordered. Hence the movement is not relative to ALL 
 	active/visible track envelopes but only to those of the same FX
 	as the selected envelope.  
-Screenshot: https://raw.githubusercontent.com/Buy-One/screenshots/main/Move%20selected%20FX%20envelope%20in%20track%20to%20top_bottom_upwards_downwards.gif	
+
+	https://raw.githubusercontent.com/Buy-One/screenshots/main/Move%20selected%20FX%20envelope%20in%20track%20to%20top_bottom_upwards_downwards.gif	
 Metapackage: true
 Provides: 	[main] . > BuyOne_Move selected FX envelope/BuyOne_Move selected FX envelope in track to top lane.lua
 		[main] . > BuyOne_Move selected FX envelope/BuyOne_Move selected FX envelope in track to bottom lane.lua


### PR DESCRIPTION
I'd like to have an explicit link to the screenshot in the description in addition to the Screenshot tag.