### PR TITLE
Release MK Slicer v2.5

### DIFF
--- a/Items Editing/cool_MK Slicer.lua
+++ b/Items Editing/cool_MK Slicer.lua
@@ -1,15 +1,37 @@
 -- @description MK Slicer
 -- @author cool
--- @version 2.15
+-- @version 2.5
 -- @changelog
---   + Now the combination Ctrl+S works when the script window is active.
---   + os.execute replaced with CF_ShellExecute for better performance and Linux compatibility.
---   + Added a hidden option to force Sync to be enabled every time the script is run.
+--   + Added Pitch Detection mode for quick conversion of monophonic melodies and drums to MIDI.
+--   + The Drums preset in Pitch Detection recognizes and creates MIDI notes of Kick, Snare and Hat.
+--   + New overwrite mode for MIDI creation in Trigger and Pitch Detection modes.
+--   + Bug fixed: now the script does not crash when trying to process Empty Items.
+--   + Fixed a bug that slows down updating the script window when Loop is running.
+--   + Bug fixed: now after initializing items with a long silence at the beginning, Gain and Threshold do not take huge values.
+--   + Bug fixed: now if after initialization item selection disappears, all functions will still work.
+--   + Bug fixed: now Marker Quantize works if the visible grid is off.
+--   + Now when zooming horizontally with the keyboard keys, the waveform is centered on the edit cursor.
+--   + "Processing, wait..." message to brighten up your waiting while processing or initializing long items.
+--   + Service messages and caring error messages now appear at the top of the window.
+--   + The script runs even if the selection is not correct. No more intrusive pop-up windows. If unsuitable items are selected, the selection is removed automatically.
+--   + Now the script can run even on multitracks. Only the topmost selected track will be analyzed.
+--   + Now loop selection is not blocked and is captured by the script only at the moments of control from the Slicer interface.
+--   + The minimum value of the HPF slider turns off the HPF filter, completely removing filtering artifacts.
+--   + Limited minimum grid and ruler resolution: now long items and small grid resolutions do not overload the processor.
+--   + Optimization in general: now the script starts instantly. CPU load reduced by 50% in idle, memory consumption during processing and initialization is reduced.
+--   + Now, when initializing for multiple items, the script does not try to apply Heal by default. Glue only.
+--   + Smart Glue: On initialization, if a multitrack is selected, Glue happens selectively. Single items, MIDI and Empty Items are ignored.
+--   + Now in MIDI Trigger mode Glue will not work if the item's Rate is changed. The trigger has become non-destructive for single items.
+--   + Now the value of the pitch band is forced for ReaSamplomatic5000 instances. In the code, it is possible to turn off the boost or change the pitchband range.
+--   + After finishing MIDI processing, when no audio is loaded, loop selection is not captured by the script.
+--   + Improved responsiveness of sliders when using the mousewheel.
+--   + Increased the maximum width of the waveform window for ultra-wide screens.
+--   + Donate service changed to valid.
 -- @link Forum Thread https://forum.cockos.com/showthread.php?t=232672
 -- @screenshot MKSlicer2.0 https://i.imgur.com/QFWHt9a.png
 -- @donation
---   Donate via PayPal https://www.paypal.me/MKokarev
---   Donate via Yandex https://money.yandex.ru/to/41001256406969
+--   Donate by BuyMeACoffee https://www.buymeacoffee.com/MaximKokarev
+--   Donate by YooMoney https://yoomoney.ru/to/41001256406969
 -- @about
 --   # MK Slicer
 --
@@ -62,7 +84,7 @@
 --   Sometimes a script applies glue to items. For example, when several items are selected and when a MIDI is created in a sampler mode.
 
 --[[
-MK Slicer v2.15 by Maxim Kokarev 
+MK Slicer v2.5 by Maxim Kokarev 
 https://forum.cockos.com/member.php?u=121750
 
 Co-Author of the compilation - MyDaw
@@ -81,17 +103,51 @@ http://forum.cockos.com/member.php?u=50462
 Export to ReaSamplOmatic5000 function from RS5k manager by MPL 
 https://forum.cockos.com/showthread.php?t=207971  
 
-Razor Edit functions by BirdBird and Juliansander
+Razor Edit functions by BirdBird, Juliansander and Embass:
 https://forum.cockos.com/showthread.php?t=241604
 
-Randomise Reverse Based on "me2beats_Toggle random active takes reverse"
+Randomise Reverse based on "me2beats_Toggle random active takes reverse"
 script by me2beats
 https://forum.cockos.com/member.php?u=100851
+
+Pitch to Notes table based on FeedTheCat code:
+https://forum.cockos.com/showthread.php?t=259698
+
+Pitch Detection based on Justin Frankel code:
+http://forum.cockos.com/showpost.php?p=1777001&postcount=2
+
+"Unselect an item if there is only one on the track" code by Edgemeal:
+https://forum.cockos.com/showpost.php?p=2575889&postcount=231
 ]]
 
+----------------------------Advanced User Settings--(Modify with care!)----------------------------------
+
+RememberLast = 1  -- (Remember some sliders positions from last session. 1 - On, 0 - Off)
+AutoXFadesOnSplitOverride = 1 -- (Override "Options: Toggle auto-crossfade on split" option. 0 - Don't Override, 1 - Override)
+Compensate_Oct_Offset = 0 -- (Trigger: octave shift of note names to compensate "MIDI octave name display offset". -4 - Min, 4 - Max)
+WFiltering = 0 -- (Waveform Visual Filtering while Window Scaling. 1 - On, 0 - Off)
+ShowRuler = 1 -- (Show Project Grid Green Markers. 1 - On, 0 - Off)
+ShowInfoLine = 0 -- (Show Project Info Line (Grid and Swing status). 1 - On, 0 - Off)
+ShowTrackAndItemInfo = 1 -- (Show processed item and related track number. 1 - On, 0 - Off)
+SnapToStart = 1 --(Snap Play Cursor to Waveform Start. 1 - On, 0 - Off)
+ZeroCrossingType = 1 -- (1 - Snap to Nearest (working fine), 0 - Snap to previous (not recommend, for testing only!))
+SnapToSemi = 1 -- (Random pitch steps by semitones 2 - On(Intervals), 1 - On(chromatic), 0 - Off(cents))
+ForceSync = 0 -- (force Sync On on the script starts: 1 - On (Force On), 0 - Off (Save Previous State))
+No_Heal_On_Init = 1 --(Don't try healing multiple items on the script starts: 1 - On (Glue only), 0 - Off (Trying to undestructive Heal items, if not successful, then Glue))
+No_Glue_On_Init = 0 --(Don't try gluing multiple items on the script starts: 1 - On ( No Glue, not recommend), 0 - Off (Glue, Recommended))
+GroupingWhenSlicing = 1 -- (Grouping Multitrack When Slicing: 1 - On, 0 - Off. Disabling greatly increases the speed of Slicing multitrack. )
+
+RebuildPeaksOnStart = 0 -- (Rebuilding waveform peaks when the script starts. Required for Pitch Detection to work correctly on slow PC. 1 - On (Recommended), 0 - Off)
+TimeForPeaksRebuild = 0.6 -- (Additional delay required to rebuild peaks in Pitch Detection mode. If you get an empty MIDI file, you need to increase the value. I recommend values between: 0.3 (fast modern PC) and 1 (slowest PC). Default: 0.3, Recommended: 0.6 ).
+
+ForcePitchBend = 1 -- Forces a Pitch Bend value for each ReaSamplomatic5000 instance (1 - On, 0 - Off)
+PitchBend = 12 -- if ForcePitchBend if on, set max pitch bend, semitones (0 - Min, 12 - Max)
+
+--------------------------------End of Advanced User Settings------------------------------------------
+
 ----------------------------------------------------------------------------
--- Some functions(local functions work faster in big cicles(~30%)) ------------
--- R.Ierusalimschy - "lua Performance Tips" ----------------------------------
+-- Some functions(local functions work faster in big cicles(~30%)) -----
+-- R.Ierusalimschy - "lua Performance Tips" ------------------------------
 ----------------------------------------------------------------------------
 local r = reaper
 local abs  = math.abs
@@ -104,7 +160,7 @@ local exp = math.exp
 local logx = math.log
 local huge = math.huge      
 local random = math.random
-
+-----------------------------------------------------------------------------
 Slice_Status = 1
 SliceQ_Status = 0
 MarkersQ_Status = 0
@@ -120,6 +176,7 @@ Random_Status = 0
 MouseUpX = 0
 MIDISampler = 0
 Midi_sampler_offs_stat = 0
+Pitch_Det_offs_stat = 0
 Reset_to_def = 0
 RE_Status = 0
 SliceQ_Status_Rand = 0
@@ -132,22 +189,7 @@ Grid16_on = 0
 Grid32_on = 0
 Grid64_on = 0
 GridT_on = 0
-
-----------------------------Advanced Settings-------------------------------------------
-
-RememberLast = 1            -- (Remember some sliders positions from last session. 1 - On, 0 - Off)
-AutoXFadesOnSplitOverride = 1 -- (Override "Options: Toggle auto-crossfade on split" option. 0 - Don't Override, 1 - Override)
-Compensate_Oct_Offset = 0 -- (Trigger: octave shift of note names to compensate "MIDI octave name display offset". -4 - Min, 4 - Max)
-WFiltering = 0 -- (Waveform Visual Filtering while Window Scaling. 1 - On, 0 - Off)
-ShowRuler = 1 -- (Show Project Grid Green Markers. 1 - On, 0 - Off)
-ShowInfoLine = 0 -- (Show Project Info Line. 1 - On, 0 - Off)
-SnapToStart = 1 --(Snap Play Cursor to Waveform Start. 1 - On, 0 - Off)
-ZeroCrossingType = 1 -- (1 - Snap to Nearest (working fine), 0 - Snap to previous (not recommend, for testing only!))
-SnapToSemi = 1 -- (Random pitch steps by semitones 2 - On(Intervals), 1 - On(chromatic), 0 - Off(cents))
-ForceSync = 0 -- (force Sync On on the script starts: 1 - On (Force On), 0 - Off (Save Previous State))
-
-------------------------End of Advanced Settings----------------------------------------
-
+ErrMsg_Status = 0
 -----------------------------------States and UA  protection-----------------------------
 
 Docked = tonumber(r.GetExtState('cool_MK Slicer.lua','Docked'))or 0;
@@ -155,7 +197,10 @@ EscToExit = tonumber(r.GetExtState('cool_MK Slicer.lua','EscToExit'))or 1;
 MIDISamplerCopyFX = tonumber(r.GetExtState('cool_MK Slicer.lua','MIDISamplerCopyFX'))or 1;
 MIDISamplerCopyRouting = tonumber(r.GetExtState('cool_MK Slicer.lua','MIDISamplerCopyRouting'))or 1;
 MIDI_Mode = tonumber(r.GetExtState('cool_MK Slicer.lua','Midi_Sampler.norm_val'))or 1;
-Sampler_preset_state = tonumber(r.GetExtState('cool_MK Slicer.lua','Sampler_preset.norm_val'))or 1;
+Sampler_preset_state = tonumber(r.GetExtState('cool_MK Slicer.lua','Sampler_preset.norm_val'))or 1; 
+Create_Replace_state = tonumber(r.GetExtState('cool_MK Slicer.lua','Create_Replace.norm_val'))or 1; 
+Pitch_Det_Options_state = tonumber(r.GetExtState('cool_MK Slicer.lua','Pitch_Det_Options.norm_val'))or 1;
+Pitch_Det_Options_state2 = tonumber(r.GetExtState('cool_MK Slicer.lua','Pitch_Det_Options2.norm_val'))or 1;
 AutoScroll = tonumber(r.GetExtState('cool_MK Slicer.lua','AutoScroll'))or 0;
 PlayMode = tonumber(r.GetExtState('cool_MK Slicer.lua','PlayMode'))or 0;
 Loop_on = tonumber(r.GetExtState('cool_MK Slicer.lua','Loop_on'))or 1;
@@ -207,11 +252,14 @@ if loopcheckstart == loopcheckending and loopcheckstart and loopcheckending then
      loopcheck = 1
 end
 
+function GetLoopTimeRange()
+start, ending = r.GetSet_LoopTimeRange( 0, 0, 0, 0, 0 )
+end
+
     r.Undo_BeginBlock() 
 r.PreventUIRefresh(1)
 
 -------------------------------Check time range and unselect-----------------------------
-
 function unselect_if_out_of_time_range()
 
 local j=0; -- unselect if out of time range 
@@ -219,7 +267,7 @@ while(true) do;
   j=j+1;
   local track = r.GetSelectedTrack(0,j-1);
   if track then;
-  local start, ending = r.GetSet_LoopTimeRange( 0, 0, 0, 0, 0 )
+    GetLoopTimeRange()
       local i=0; 
       while(true) do;
         i=i+1;
@@ -244,8 +292,8 @@ while(true) do;
 end;
 
 end
-------------------------------Detect MIDI takes-------------------------------------------
 
+------------------------------Detect MIDI takes/Empty Items--------------------------------
 function take_check()
 local i=0;
 while(true) do;
@@ -253,8 +301,13 @@ while(true) do;
   local item = r.GetSelectedMediaItem(0,i-1);
   if item then;
   active_take = r.GetActiveTake(item)  -- active take in item
-    if r.TakeIsMIDI(active_take) then 
-    Take_Check = 1 end
+       if active_take  then
+             if r.TakeIsMIDI(active_take) then 
+              Take_Check = 1 -- MIDI Item
+            end
+       else
+  --     Take_Check = 1 -- Empty Item
+       end
   else;
     break;
   end;
@@ -262,268 +315,78 @@ end;
 
 end
 
--------------------------------Check Razor Edits-----------------------------
-function GetItemsInRange(track, areaStart, areaEnd)
-    local items = {}
-    local itemCount = r.CountTrackMediaItems(track)
-    for k = 0, itemCount - 1 do 
-        local item = r.GetTrackMediaItem(track, k)
-        local pos = r.GetMediaItemInfo_Value(item, "D_POSITION")
-        local length = r.GetMediaItemInfo_Value(item, "D_LENGTH")
-        local itemEndPos = pos+length
-        if (itemEndPos > areaStart and itemEndPos <= areaEnd) or          --check if item is in area bounds
-            (pos >= areaStart and pos < areaEnd) or
-            (pos <= areaStart and itemEndPos >= areaEnd) then
-                table.insert(items,item)
-        end
-    end
-    return items
-end
+----------------------Select only tracks of selected items-----------------------------
+function sel_tracks_items() --
 
-function SetTrackRazorEdit(track, areaStart, areaEnd, clearSelection)
-    if clearSelection == nil then clearSelection = false end   
-    if clearSelection then
-        local ret, area = r.GetSetMediaTrackInfo_String(track, 'P_RAZOREDITS', '', false)   
-        local str = {}  --parse string, all this string stuff could probably be written better
-        for j in string.gmatch(area, "%S+") do table.insert(str, j) end       
-        local j = 1   --strip existing selections across the track
-        while j <= #str do
-            local GUID = str[j+2]
-            if GUID == '""' then 
-                str[j] = ''
-                str[j+1] = ''
-                str[j+2] = ''
-            end
-            j = j + 3
-        end
-        --insert razor edit 
-        local REstr = tostring(areaStart) .. ' ' .. tostring(areaEnd) .. ' ""'
-        table.insert(str, REstr)
-        local finalStr = ''
-        for i = 1, #str do
-            local space = i == 1 and '' or ' '
-            finalStr = finalStr .. space .. str[i]
-        end
-        local ret, area = r.GetSetMediaTrackInfo_String(track, 'P_RAZOREDITS', finalStr, true)
-        return ret
-    else         
-        local ret, area = r.GetSetMediaTrackInfo_String(track, 'P_RAZOREDITS', '', false)
-        local str = area ~= nil and area .. ' ' or ''
-        str = str .. tostring(areaStart) .. ' ' .. tostring(areaEnd) .. '  ""'       
-        local ret, area = r.GetSetMediaTrackInfo_String(track, 'P_RAZOREDITS', str, true)
-        return ret
-    end
-end
-
-function GetRazorEdits()
-    local trackCount = r.CountTracks(0)
-    local areaMap = {}
-    for i = 0, trackCount - 1 do
-        local track = r.GetTrack(0, i)
-        local ret, area = r.GetSetMediaTrackInfo_String(track, 'P_RAZOREDITS', '', false)
-        if area ~= '' then
-            --PARSE STRING
-            local str = {}
-            for j in string.gmatch(area, "%S+") do
-                table.insert(str, j)
-            end       
-            --FILL AREA DATA
-            local j = 1
-            while j <= #str do
-                local areaStart = tonumber(str[j])        --area data
-                local areaEnd = tonumber(str[j+1]) 
-                local items = {}  --get item data
-                items = GetItemsInRange(track, areaStart, areaEnd)
-                  r.SetTrackSelected(track, true) -- Set Track Selected
-                local areaData = {
-                    areaStart = areaStart,
-                    areaEnd = areaEnd,                
-                    track = track,
-                    items = items,                   
-                }
-                table.insert(areaMap, areaData)
-                j = j + 3
-            end
-        end
-    end
-    return areaMap
-end
-
-function SplitRazorEdits(razorEdits)
-left, right = huge, -huge
-    local areaItems = {}
-    local tracks = {}
-    for i = 1, #razorEdits do
-        local areaData = razorEdits[i]
-        if not areaData.isEnvelope then
-            local items = areaData.items           
-            if tracks[areaData.track] ~= nil then  --recalculate item data for tracks with previous splits
-                items = GetItemsInRange(areaData.track, areaData.areaStart, areaData.areaEnd)
-            end            
-            for j = 1, #items do 
-                local item = items[j]        
-                 if areaData.areaStart  < left  then left  = areaData.areaStart end  --combine areas and set time selection
-                 if areaData.areaEnd > right then right = areaData.areaEnd end
-                 if left <= right then
-                      r.GetSet_LoopTimeRange2(0, true, false, left, right, false)
-                      table.insert(areaItems, item)
-                 end
-            end
-            tracks[areaData.track] = 1
-        end
-    end
-    return areaItems
-end
-
- -- Unselect All Tracks if RE exist --
-    for i = 0, r.CountTracks(0) - 1 do
-        local _, check_area = r.GetSetMediaTrackInfo_String(r.GetTrack(0, i), 'P_RAZOREDITS', '', false)
-        if check_area ~= '' then
-                r.Main_OnCommand(40297, 0) -- Unselect all tracks
-                RE_Status = 1
-        end
-    end
-
- -- Select Items by RE --
-local selections = GetRazorEdits()
-local items = SplitRazorEdits(selections)
-for i = 1, #items do
-    local item = items[i]
-    r.SetMediaItemSelected(item, true)
-end
-
-take_check()
-sel_tr_count = r.CountSelectedTracks(0)
-  if sel_tr_count == 1 then
-        r.Main_OnCommand(42406, 0) -- Clear RE Areas
-     local   start, ending = r.GetSet_LoopTimeRange( 0, 0, 0, 0, 0 )
-           if start ~= ending and Take_Check ~= 1 then
-               r.Main_OnCommand(40061, 0) -- Split at Time Selection
-               r.Main_OnCommand(40635, 0) -- Remove Time Selection
-           end
-    elseif sel_tr_count > 1 then
-    gfx.quit() 
-    r.ShowConsoleMsg("Only single track items, please. User manual: https://forum.cockos.com/showthread.php?t=232672")
-    return
-    elseif sel_tr_count ==0 then
-  end
-
-local i=0;
-while(true) do;
-  i=i+1;
-  local item = r.GetSelectedMediaItem(0,i-1);
-  if item then;
-  active_take = r.GetActiveTake(item)  -- active take in item
-    if r.TakeIsMIDI(active_take) then 
-       gfx.quit() 
-       r.ShowConsoleMsg("Only Wave items, please. Additional help: https://forum.cockos.com/showthread.php?t=232672") 
-       return 
-    end
-  else;
-    break;
-  end;
-end;
-
-function re_createRE()
-    local itemCount = r.CountSelectedMediaItems(0) -- re-create deleted RE
-    for i = 0, itemCount - 1 do
-        local item = r.GetSelectedMediaItem(0, i)
-        local track = r.GetMediaItem_Track(item)      
-        local itemStartPosition = r.GetMediaItemInfo_Value(item, 'D_POSITION')
-        local itemLength = r.GetMediaItemInfo_Value(item, 'D_LENGTH')
-        local itemEndPosition = itemStartPosition + itemLength
-        SetTrackRazorEdit(track, itemStartPosition, itemEndPosition, false)
-    end
-end
-
-
-function deferinit() -- continuous selection items in RE
-for t = 0, reaper.CountTracks(0)-1 do
-    local track = reaper.GetTrack(0, t)
-    local tR = {}
-    local razorOK, razorStr = reaper.GetSetMediaTrackInfo_String(track, "P_RAZOREDITS", "", false)
-    if razorOK and #razorStr ~= 0 then
-        for razorLeft, razorRight, envGuid in razorStr:gmatch([[([%d%.]+) ([%d%.]+) "([^"]*)"]]) do
-            if envGuid == "" then
-                local razorLeft, razorRight = tonumber(razorLeft), tonumber(razorRight)
-                table.insert(tR, {left = razorLeft, right = razorRight})
-            end
-        end
-    end
-    for i = 0, reaper.CountTrackMediaItems(track)-1 do
-        local item = reaper.GetTrackMediaItem(track, i)
-        reaper.SetMediaItemSelected(item, false)
-        local left = reaper.GetMediaItemInfo_Value(item, "D_POSITION")
-        local right = left + reaper.GetMediaItemInfo_Value(item, "D_LENGTH")
-        for _, r in ipairs(tR) do
-            if left < r.right and right > r.left then
-                reaper.SetMediaItemSelected(item, true)
-            end
-        end
-    end
-end
-reaper.UpdateArrange()
-      if char~=-1 then r.defer(deferinit)  else end     -- defer     r.defer(deferinit)
-end
-
-
-        if RE_Status == 1 then
-             re_createRE()
-             deferinit()
-        end
-
----------------------------------------End of RE_Splits----------------------------------------
-
-function sel_tracks_items() --Select only tracks of selected items
-
-  UnselectAllTracks()
   selected_items_count = r.CountSelectedMediaItems(0)
 
-  for i = 0, selected_items_count - 1  do
-    item = r.GetSelectedMediaItem(0, i) -- Get selected item i
-    track = r.GetMediaItem_Track(item)
-    r.SetTrackSelected(track, true)        
-  end 
+          UnselectAllTracks()
+        
+            for i = 0, selected_items_count - 1  do
+                 item = r.GetSelectedMediaItem(0, i) -- Get selected item i
+                 if item then 
+                     track = r.GetMediaItem_Track(item)
+                     r.SetTrackSelected(track, true)        
+                 end  
+           end
 end
 
 function UnselectAllTracks()
   first_track = r.GetTrack(0, 0)
           if first_track then
-        r.SetOnlyTrackSelected(first_track)
-        r.SetTrackSelected(first_track, false)
+            r.SetOnlyTrackSelected(first_track)
+            r.SetTrackSelected(first_track, false)
           end
 end
 
-if ObeyingItemSelection == 1 then
-sel_tracks_items()
-end
--------------------------------------------------------------------------------------------
-r.Main_OnCommand(r.NamedCommandLookup('_SWS_SAVESEL'), 0)  -- Save track selection
------------------------------------ObeyingTheSelection------------------------------------
-
-function collect_param()    -- collect parameters
-   selected_tracks_count = r.CountSelectedTracks(0)
-   number_of_takes =  r.CountSelectedMediaItems(0)
-   if number_of_takes == 0 then return end
-   sel_item = r.GetSelectedMediaItem(0, 0)    -- get selected item 
-   active_take = r.GetActiveTake(sel_item)  -- active take in item
- end
-
-collect_param()
-local start, ending = r.GetSet_LoopTimeRange( 0, 0, 0, 0, 0 )
-time_sel_length = ending - start
-if ObeyingTheSelection == 1 and ObeyingItemSelection == 0 and start ~= ending then
-    r.Main_OnCommand(40289, 0) -- Item: Unselect all items
-          if time_sel_length >= 0.25 and selected_tracks_count == 1 then
-              r.Main_OnCommand(40718, 0) -- Item: Select all items on selected tracks in current time selection
+------------------------Time Selection To Selected Items (First Track Only)------------------------
+function TimeSelToFirstTrackItems()
+::start::
+local SelItems = {p0sition_b, ending_b}
+local table_pos = 1 
+local item, sel, track, p0sition, l3ngth, it_start, it_end, items_count, it_table
+GetLoopTimeRange()
+track = r.GetSelectedTrack(0,0,0) -- first selected track
+    if track then
+      items_count = r.CountTrackMediaItems(track)     
+          for i=0, items_count-1 do
+                  item = r.GetTrackMediaItem(track,i)
+                  sel =  r.IsMediaItemSelected(item)
+                  if item and sel == true then
+   
+                        p0sition    = r.GetMediaItemInfo_Value(item, "D_POSITION")
+                        l3ngth = r.GetMediaItemInfo_Value(item, "D_LENGTH")
+         
+                         SelItems[table_pos] = {
+                                     p0sition_b = p0sition,
+                                     ending_b = p0sition+l3ngth
+                                                }
+                          table_pos = table_pos + 1
+                   end
+           end
+   
+      it_table = #SelItems
+      for i = 1, it_table do
+         it_start = SelItems[1].p0sition_b -- first item start
+         it_end = SelItems[it_table].ending_b -- last item end
+      end
+   
+         if it_start and it_end then
+   
+                r.GetSet_LoopTimeRange( 1, 0, it_start, it_end, 0 ) -- set loop/selection area
+    
+                if sel and ((it_start >= start and it_start < ending) or (it_end <= ending and it_end > start) or (it_start < start and it_end > ending)) and start ~= ending then -- if selection exist and outside the item
+                    r.Main_OnCommand(40635, 0) -- Remove Time Selection
+                    goto start
+                end
+   
           end
+   
+     end
 end
 
-count_itms =  r.CountSelectedMediaItems(0)
-if ObeyingTheSelection == 1 and count_itms ~= 0 and start ~= ending and time_sel_length >= 0.25 then
-   take_check()
-   if Take_Check ~= 1 and selected_tracks_count == 1 then
-
+------------Split items by time selection,unselect with items outside of time selection if there is selection inside-------
+function SplitByTimeAndDeselect()
     --------------------------------------------------------
     local function no_undo() r.defer(function()end)end;
     --------------------------------------------------------
@@ -573,30 +436,295 @@ if ObeyingTheSelection == 1 and count_itms ~= 0 and start ~= ending and time_sel
         no_undo();
     end;    
     r.UpdateArrange();
+end
 
-        collect_param()  
 
-   for i = 0, number_of_takes-1 do -- take fx check
-     local item = r.GetSelectedMediaItem(0, i)
-     local take_count = r.CountTakes(item)
-     for j = 0, take_count-1 do
-       local take = r.GetMediaItemTake(item, j) 
-       if r.TakeFX_GetCount(take) > 0 then 
-        tkfx = 1
+---------------------------------UnSelect MIDI And EmptyItems-----------------------------------------
+function UnSelectMIDIAndEmptyItems()
+
+r.Undo_BeginBlock();
+r.PreventUIRefresh(1);
+local cursorpos = r.GetCursorPosition()
+
+local Empty_Item = 0
+local MIDI_Item = 0
+for i = 0, r.CountSelectedTracks(0)-1  do
+local track = r.GetSelectedTrack(0, i)
+     for k = 0, r.CountTrackMediaItems(track)-1 do
+            local itm = r.GetTrackMediaItem(track, k)
+            if itm then  
+                 local take = r.GetActiveTake(itm)
+   
+                  if r.IsMediaItemSelected(itm) then
+                          if take == nil then Empty_Item = 1 end
+                          if take and r.TakeIsMIDI(take) == true then MIDI_Item = 1 end
+                  
+                          if (Empty_Item == 1 or MIDI_Item == 1) then
+                             r.SetMediaItemSelected(itm, false) 
+                             Empty_Item = 0
+                             MIDI_Item = 0
+                          end
+                   end
+            end
+      end
+end
+
+r.SetEditCurPos(cursorpos,0,0)
+
+r.PreventUIRefresh(-1);
+r.Undo_EndBlock("UnSelect MIDI And EmptyItems",-1);
+r.UpdateArrange()
+
+end  
+UnSelectMIDIAndEmptyItems()
+
+---------------------------------Selective Glue Multitrack-----------------------------------------
+function GlueMultitrack()
+r.Undo_BeginBlock();
+r.PreventUIRefresh(1);
+local cursorpos = r.GetCursorPosition()
+
+  r.Main_OnCommand(40290, 0) -- selection by items
+  
+  GetLoopTimeRange()
+  
+  function IsOneSelectedMediaItem(track)
+    local sel_count, index, TakeFX = 0,0,0
+    for i = 0, r.CountTrackMediaItems(track)-1 do
+    local itm = r.GetTrackMediaItem(track, i)
+    local item_pos =  r.GetMediaItemInfo_Value( itm, 'D_POSITION' )
+    local item_end = item_pos + r.GetMediaItemInfo_Value( itm, 'D_LENGTH' )
+    local take = r.GetActiveTake(itm)
+ 
+       if take and r.IsMediaItemSelected(itm) then
+           if r.TakeFX_GetCount(take) > 0 then TakeFX = 1 end
        end
-     end
-   end
 
-        if number_of_takes ~= 1 and tkfx ~= 1 then
+            if r.IsMediaItemSelected(itm) and TakeFX ~= 1 then  -- if selected and no take fx
+                if ((item_pos >= start and item_pos < ending) or (item_end <= ending and item_end > start) or (item_pos < start and item_end > ending)) or start == ending then
+                    sel_count = sel_count + 1
+                    if sel_count > 1 then return end
+                    index = i
+                end
+            end 
+
+    end
+       if sel_count == 1 then return r.GetTrackMediaItem(track, index) end
+  end
+  
+  for i = 0, r.CountSelectedTracks(0)-1  do
+      local track = r.GetSelectedTrack(0, i)
+      local item = IsOneSelectedMediaItem(track)
+         if item then  
+               r.SetMediaItemSelected(item, false) 
+          end
+  end
+
+  UnSelectMIDIAndEmptyItems()
+  if item or ObeyingItemSelection == 0 then 
+     r.Main_OnCommand(40362, 0) -- glue
+     r.Main_OnCommand(40718, 0) -- Item: Select all items on selected tracks in current time selection
+     UnSelectMIDIAndEmptyItems()
+  end
+
+r.SetEditCurPos(cursorpos,0,0)
+
+r.PreventUIRefresh(-1);
+r.Undo_EndBlock("Glue Multitrack (skip single items)",-1);
+r.UpdateArrange()
+
+end  
+
+---------------------------Get Track Number and Item Name to table----------------------------
+local function InitTrackItemName()
+
+     local track, track_num, item, take
+     
+     TableTI = {}
+     
+      track = r.GetSelectedTrack(0, 0)
+
+      if not track then 
+        track = r.GetTrack(0, 0)
+        r.SetTrackSelected(track, true)
+      end
+ 
+      track_num = r.GetMediaTrackInfo_Value(track, "IP_TRACKNUMBER")
+      TableTI.track  = ('%d'):format(track_num) -- convert 3.0 to 3
+
+      item = r.GetSelectedMediaItem(0, 0)
+      if item then
+         take = r.GetActiveTake(item)
+         if take then
+                if Take_Check ~= 1 then -- if midi take, then return end
+               TableTI.item = r.GetTakeName(take)
+               else
+     --          TableTI.item = 'MIDI'  
+                  return
+               end
+         else
+            TableTI.item = 'Empty Item'  
+         end
+      end
+
+end
+
+-------------------------------------Check Razor Edits------------------------------------
+function RazorEditSelectionExists()
+    for i=0, r.CountTracks(0)-1 do
+        local retval, x = r.GetSetMediaTrackInfo_String(r.GetTrack(0,i), "P_RAZOREDITS", "string", false)
+        if x ~= "" then return true end
+    end--for   
+    return false
+end --RazorEditSelectionExists()
+
+RE_exist = RazorEditSelectionExists()
+
+if RE_exist == true then
+r.PreventUIRefresh(1)
+-------------------Razor edit - Set time selection to razor areas----------------------------------
+left, right = math.huge, -math.huge
+for t = 0, r.CountTracks(0)-1 do
+    local track = r.GetTrack(0, t)
+    local razorOK, razorStr = r.GetSetMediaTrackInfo_String(track, "P_RAZOREDITS", "", false)
+    if razorOK and #razorStr ~= 0 then
+        for razorLeft, razorRight, envGuid in razorStr:gmatch([[([%d%.]+) ([%d%.]+) "([^"]*)"]]) do
+            local razorLeft, razorRight = tonumber(razorLeft), tonumber(razorRight)
+            if razorLeft  < left  then left  = razorLeft end
+            if razorRight > right then right = razorRight end
+        end
+    end
+end
+if left <= right then
+    r.GetSet_LoopTimeRange2(0, true, false, left, right, false)
+end
+
+---------------------Select media items that overlap razor areas--------------------------------
+for t = 0, r.CountTracks(0)-1 do
+    local track = r.GetTrack(0, t)
+    local tR = {}
+    local razorOK, razorStr = r.GetSetMediaTrackInfo_String(track, "P_RAZOREDITS", "", false)
+    if razorOK and #razorStr ~= 0 then
+        for razorLeft, razorRight, envGuid in razorStr:gmatch([[([%d%.]+) ([%d%.]+) "([^"]*)"]]) do
+            if envGuid == "" then
+                local razorLeft, razorRight = tonumber(razorLeft), tonumber(razorRight)
+                table.insert(tR, {left = razorLeft, right = razorRight})
+            end
+        end
+    end
+    for i = 0, r.CountTrackMediaItems(track)-1 do
+        local item = r.GetTrackMediaItem(track, i)
+        r.SetMediaItemSelected(item, false)
+        local left = r.GetMediaItemInfo_Value(item, "D_POSITION")
+        local right = left + r.GetMediaItemInfo_Value(item, "D_LENGTH")
+        for _, rr in ipairs(tR) do
+            if left < rr.right and right > rr.left then
+                r.SetMediaItemSelected(item, true)
+            end
+        end
+    end
+end
+--------------------------------------------------------------------------------------------------------------
+            GetLoopTimeRange()
+                  if start ~= ending then
+                        r.Main_OnCommand(40061, 0) -- Split at Time Selection
+                  --   r.Main_OnCommand(40635, 0) -- Remove Time Selection
+                  unselect_if_out_of_time_range()
+                  end
+         
+         sel_tracks_items()
+         UnSelectMIDIAndEmptyItems()
+         sel_tracks_items()
+
+-----------------------------------------Set RE by Selected Items------------------------------------------         
+
+         	r.Main_OnCommand(42406, 0) -- clear area sel
+         	GetLoopTimeRange()
+         	if start ~= ending then
+         		local str_track_razor_edits = string.format([[%s %s '']], start, ending)	
+         		for i = 0, r.CountSelectedTracks(0) - 1 do
+         			local track = r.GetSelectedTrack(0, i)
+         			r.GetSetMediaTrackInfo_String(track, "P_RAZOREDITS", str_track_razor_edits, true) -- set
+         		end
+         	end
+
+         r.PreventUIRefresh(-1)
+         r.UpdateArrange()
+         
+  else -- if not RE
+
+            r.PreventUIRefresh(1)
+            sel_tracks_items()
+
+            GetLoopTimeRange()
+                  if start ~= ending then -- if selection exist
+                        r.Main_OnCommand(40061, 0) -- Split at Time Selection
+                        TimeSelToFirstTrackItems()
+                        UnSelectMIDIAndEmptyItems()
+                  else
+                        TimeSelToFirstTrackItems()
+                        UnSelectMIDIAndEmptyItems()
+                        GetLoopTimeRange() -- check again
+                          if start ~= ending then -- if selection exist
+                             r.Main_OnCommand(40061, 0) -- Split at Time Selection
+                          end
+                  end
+                 unselect_if_out_of_time_range()
+                 r.PreventUIRefresh(-1)
+                 r.UpdateArrange()
+
+end -- if RE_exist
+---------------------------------------End of RE_Splits----------------------------------------
+
+if ObeyingItemSelection == 1 then
+sel_tracks_items()
+end
+
+InitTrackItemName() 
+
+-------------------------------------------------------------------------------------------
+r.Main_OnCommand(r.NamedCommandLookup('_SWS_SAVESEL'), 0)  -- Save track selection
+-----------------------------------ObeyingTheSelection------------------------------------
+
+function collect_param()    -- collect parameters
+   selected_tracks_count = r.CountSelectedTracks(0)
+   number_of_takes =  r.CountSelectedMediaItems(0)
+   if number_of_takes == 0 then return end
+   sel_item = r.GetSelectedMediaItem(0, 0)    -- get selected item 
+   active_take = r.GetActiveTake(sel_item)  -- active take in item
+ end
+
+collect_param()
+GetLoopTimeRange()
+time_sel_length = ending - start
+if ObeyingTheSelection == 1 and ObeyingItemSelection == 0 and start ~= ending then
+    r.Main_OnCommand(40289, 0) -- Item: Unselect all items
+          if time_sel_length >= 0.25 then
+              r.Main_OnCommand(40718, 0) -- Item: Select all items on selected tracks in current time selection
+              UnSelectMIDIAndEmptyItems()
+          end
+end
+
+count_itms =  r.CountSelectedMediaItems(0)
+if ObeyingTheSelection == 1 and count_itms ~= 0 and start ~= ending and time_sel_length >= 0.25 then
+   take_check()
+   if Take_Check ~= 1 then
+
+    SplitByTimeAndDeselect()
+
+    collect_param()  
+
+        if number_of_takes ~= 1 and No_Heal_On_Init == 0 then
            r.Main_OnCommand(40548, 0)  -- Heal Splits -- (если больше одного айтема и не миди айтем, то попытка не деструктивно склеить).
         end
-       collect_param()    
-       if number_of_takes ~= 1 then -- проверяем ещё раз. Если не удалось, клеим деструктивно.
-           r.Main_OnCommand(41588, 0) -- glue (если больше одного айтема и не миди айтем, то клей).
-           tkfx = 0
+  
+       if No_Glue_On_Init == 0 then -- проверяем ещё раз. Если не удалось, клеим деструктивно.
+             GlueMultitrack()
        end
+
    end
 end
+
 -----------------------------------------------------------------------------------------------------
 
 local cursorpos = r.GetCursorPosition()
@@ -621,63 +749,29 @@ function collect_itemtake_param()    -- collect parameter on sel item and active
    if number_of_takes == 0 then return end
    sel_item = r.GetSelectedMediaItem(0, 0)    -- get selected item 
    active_take = r.GetActiveTake(sel_item)  -- active take in item
-   src = r.GetMediaItemTake_Source(active_take)
-   srate =  r.GetMediaSourceSampleRate(src) -- take samplerate (simple wave/MIDI detection)
    mute_check = r.GetMediaItemInfo_Value(sel_item, "B_MUTE")
  end
  
 
    collect_itemtake_param()              -- get bunch of parameters about this item
 
-if selected_tracks_count > 1 then 
-gfx.quit() 
-r.ShowConsoleMsg("Only single track items, please. User manual: https://forum.cockos.com/showthread.php?t=232672")
-return 
-end -- не запускать, если айтемы находятся на разных треках.
-
-local i=0;
-while(true) do;
-  i=i+1;
-  local item = r.GetSelectedMediaItem(0,i-1);
-  if item then;
-  active_take = r.GetActiveTake(item)  -- active take in item
-    if r.TakeIsMIDI(active_take) then 
-       gfx.quit() 
-       r.ShowConsoleMsg("Only Wave items, please. Additional help: https://forum.cockos.com/showthread.php?t=232672") 
-       return 
-    end
-  else;
-    break;
-  end;
-end;
-
-   for i = 0, number_of_takes-1 do -- take fx check
-     local item = r.GetSelectedMediaItem(0, i)
-     local take_count = r.CountTakes(item)
-     for j = 0, take_count-1 do
-       local take = r.GetMediaItemTake(item, j) 
-       if r.TakeFX_GetCount(take) > 0 then 
-        tkfx = 1
-       end
-     end
-   end
-
- if number_of_takes ~= 1 and srate ~= nil and tkfx ~= 1 then
+if number_of_takes ~= 1 and No_Heal_On_Init == 0 then
      r.Main_OnCommand(40548, 0)  -- Heal Splits -- (если больше одного айтема и не миди айтем, то клей, попытка не деструктивно склеить).
 end
 
-   collect_itemtake_param()    
-
- if number_of_takes ~= 1 and srate ~= nil then -- проверяем ещё раз. Если не удалось, клеим деструктивно.
-     r.Main_OnCommand(41588, 0) -- glue (если больше одного айтема и не миди айтем, то клей).
-     tkfx = 0
+ if No_Glue_On_Init == 0  then -- проверяем ещё раз. Если не удалось, клеим деструктивно.
+             GlueMultitrack()
  end
+
+
+
 ------------------------------------------------------------------------------------------
 r.Main_OnCommand(r.NamedCommandLookup('_SWS_RESTORESEL'), 0)  -- Restore track selection
 ----------------------------------Get States from last session-----------------------------
 
 if RememberLast == 1 then
 CrossfadeTime = tonumber(r.GetExtState('cool_MK Slicer.lua','CrossfadeTime'))or 15;
+PitchDetect = tonumber(r.GetExtState('cool_MK Slicer.lua','PitchDetect'))or 5;
 QuantizeStrength = tonumber(r.GetExtState('cool_MK Slicer.lua','QuantizeStrength'))or 100;
 Offs_Slider = tonumber(r.GetExtState('cool_MK Slicer.lua','Offs_Slider'))or 0.5;
 HF_Slider = tonumber(r.GetExtState('cool_MK Slicer.lua','HF_Slider'))or 0.3312;
@@ -685,6 +779,7 @@ LF_Slider = tonumber(r.GetExtState('cool_MK Slicer.lua','LF_Slider'))or 1;
 Sens_Slider = tonumber(r.GetExtState('cool_MK Slicer.lua','Sens_Slider'))or 0.375;
 else
 CrossfadeTime = DefaultXFadeTime or 15;
+PitchDetect = DefaultP_Slider or 5;
 QuantizeStrength = DefaultQStrength or 100;
 Offs_Slider = DefaultOffset or 0.5;
 HF_Slider = DefaultHP or 0.3312;
@@ -760,7 +855,40 @@ function cleanup_slices()
     end;
 
 end
-
+----------------------------------Crossfades-------------------------------------------
+    local function Overlap(CrossfadeT);
+        local t,ret = {};
+        local items_count = r.CountSelectedMediaItems(0);
+        if items_count == 0 then return 0 end;
+        for i = 1 ,items_count do;
+            local item = r.GetSelectedMediaItem(0,i-1);
+            local trackIt = r.GetMediaItem_Track(item);
+            if t[tostring(trackIt)] then;
+                ----
+                ret = 1;
+                local crossfade_time = (CrossfadeT or 0)/1000;
+                local take = r.GetActiveTake(item); 
+                if take then
+                       local pos = r.GetMediaItemInfo_Value(item,'D_POSITION');
+                       local length = r.GetMediaItemInfo_Value( item,'D_LENGTH');
+                       local SnOffs = r.GetMediaItemInfo_Value( item,'D_SNAPOFFSET');
+                       local rateIt = r.GetMediaItemTakeInfo_Value(take,'D_PLAYRATE');
+                       local ofSetIt = r.GetMediaItemTakeInfo_Value(take,'D_STARTOFFS');
+       
+                       if pos < crossfade_time then crossfade_time = pos end;
+                       ----
+                       r.SetMediaItemInfo_Value(item,'D_POSITION',pos-crossfade_time);
+                       r.SetMediaItemInfo_Value(item,'D_LENGTH',length+crossfade_time);
+                       r.SetMediaItemTakeInfo_Value(take,'D_STARTOFFS',ofSetIt-(crossfade_time*rateIt));
+                       r.SetMediaItemInfo_Value(item,'D_SNAPOFFSET',SnOffs+crossfade_time);
+                end
+            else;
+                t[tostring(trackIt)] = trackIt;
+            end;
+        end;
+        if ret == 1 then r.Main_OnCommand(41059,0) end;
+        return ret or 0;
+    end;
 -------------------------Copy/Paste Sends/Returns---------------------------------------
 ---------------------------------------------------
     local function copyReceiveTrack(track,desttrIn,i);
@@ -792,11 +920,19 @@ end
     end;
     ---------------------------------------------------
 --------------------------------------------------------------------------------------------
+function beatc(beatpos)
+   local retval, measures, cml, fullbeats, cdenom = r.TimeMap2_timeToBeats(0, beatpos)
+   local _, division, _, _ = r.GetSetProjectGrid(0,false)
+   if division < 0.0078125 then division = 0.0078125 end
+   beatpos = r.TimeMap2_beatsToTime(0, fullbeats +(division*4))
+   return beatpos
+end
+--------------------------------------------------------------------------------------------
 
 function getsomerms()
 
 r.Undo_BeginBlock(); r.PreventUIRefresh(1)
- 
+
 local itemproc = r.GetSelectedMediaItem(0,0)
 
  if itemproc  then
@@ -805,63 +941,51 @@ local itemproc = r.GetSelectedMediaItem(0,0)
  function get_average_rms(take, adj_for_take_vol, adj_for_item_vol)
    local RMS_t = {}
    if take == nil then return end
-   
    local item = r.GetMediaItemTake_Item(take) -- Get parent item
    if item == nil then return end
 
-   -- Get media source of media item take
-   local take_pcm_source = r.GetMediaItemTake_Source(take)
-   if take_pcm_source == nil then return end
-   
-   -- Create take audio accessor
    local aa = r.CreateTakeAudioAccessor(take)
    if aa == nil then return end
    
-   -- Get the start time of the audio that can be returned from this accessor
    local aa_start = r.GetAudioAccessorStartTime(aa)
-   -- Get the end time of the audio that can be returned from this accessor
    local aa_end = r.GetAudioAccessorEndTime(aa)
-   local a_length = (aa_end - aa_start)/25
-      if a_length <= 1 then a_length = 1 elseif a_length > 20 then a_length = 20
-end
-            
-   -- Get the number of channels in the source media.
-   local take_source_num_channels =  r.GetMediaSourceNumChannels(take_pcm_source)
-          if take_source_num_channels > 2 then take_source_num_channels = 2 end
+   local a_length = (aa_end - aa_start)/5
+
+   local take_pcm_source = r.GetMediaItemTake_Source(take)
+   if take_pcm_source == nil then 
+      take_source_num_channels = 2
+      take_source_sample_rate = 44100
+       else
+      take_source_num_channels =  r.GetMediaSourceNumChannels(take_pcm_source)
+      take_source_sample_rate = r.GetMediaSourceSampleRate(take_pcm_source)
+    end
+ 
+if take_source_sample_rate == 0 then take_source_sample_rate = 44100 end -- if MIDI item, create fake samplerate           
+
+   if take_source_num_channels > 2 then take_source_num_channels = 2 end
    local channel_data = {} -- channel data is collected to this table
-   -- Initialize channel_data table
+
    for i=1, take_source_num_channels do
     channel_data[i] = {
                          rms = 0,
                          sum_squares = 0 -- (for calculating RMS per channel)
                        }
    end
-     
-   -- Get the sample rate. MIDI source media will return zero.
-   local take_source_sample_rate = r.GetMediaSourceSampleRate(take_pcm_source)
- 
-   -- How many samples are taken from audio accessor and put in the buffer
+
    local samples_per_channel = take_source_sample_rate/10
    
-   -- Samples are collected to this buffer
    local buffer = r.new_array(samples_per_channel * take_source_num_channels)
-   
+   buffer.clear()
    local total_samples = (aa_end - aa_start) * (take_source_sample_rate/a_length)
    
    if total_samples < 1 then return end
 
    local sample_count = 0
    local offs = aa_start
-   
    local log10 = function(x) return logx(x, 10) end
 
-   -- Loop through samples
    while sample_count < total_samples do
- 
-     -- Get a block of samples from the audio accessor.
-     -- Samples are extracted immediately pre-FX,
-     -- and returned interleaved (first sample of first channel, 
-     -- first sample of second channel...). Returns 0 if no audio, 1 if audio, -1 on error.
+
      local aa_ret =  r.GetAudioAccessorSamples(
                                              aa,                       -- AudioAccessor accessor
                                              take_source_sample_rate,  -- integer samplerate
@@ -872,9 +996,9 @@ end
                                            )
        
      if aa_ret == 1 then
-       for i=1, #buffer, take_source_num_channels do
+      local buffer_l = #buffer
+       for i=1, buffer_l, take_source_num_channels do
          if sample_count == total_samples then
-           audio_end_reached = true
            break
          end
          for j=1, take_source_num_channels do
@@ -895,7 +1019,6 @@ end
    
    r.DestroyAudioAccessor(aa)
     
-   -- Calculate corrections for take/item volume
    adjust_vol = 1
    
    if adj_for_take_vol then
@@ -907,7 +1030,6 @@ end
      adjust_vol = adjust_vol * r.GetMediaItemInfo_Value(item, "D_VOL")
    end
    
-   -- Calculate RMS for each channel
    for i=1, take_source_num_channels do
      local curr_ch = channel_data[i]
      curr_ch.rms = sqrt(curr_ch.sum_squares/total_samples) * adjust_vol
@@ -915,9 +1037,13 @@ end
    end
    return RMS_t
  end
- 
- local getrms = get_average_rms( tk, 0, 0, 0, 0)
 
+local getrms
+       if tk ~= nil and Take_Check == 0 then  
+           getrms = get_average_rms( tk, 0, 0)
+             else
+           getrms = {-20}
+       end
  ----------------------------------------------------------------------------------
  
 local inf = 1/0
@@ -926,7 +1052,8 @@ local inf = 1/0
  rms = ceil(getrms[i])
  end
 
-if rms == -inf then rms = -17 end
+if rms <= -30 then rms = -30 end
+if rms == -inf then rms = -20 end
 
 local rmsresult = string.sub(rms,1,string.find(rms,'.')+5)
 
@@ -946,15 +1073,18 @@ end
 orig_gain = out_gain*1200
 
 end
-  
+
+if tk == nil then 
+   readrms = 0.65
+   out_gain = 0.15
+end
+
 getsomerms()     
      
 function ClearExState()
-
-r.DeleteExtState('_Slicer_', 'ItemToSlice', 0)
-r.DeleteExtState('_Slicer_', 'TrackForSlice', 0)
-r.SetExtState('_Slicer_', 'GetItemState', 'ItemNotLoaded', 0)
-
+    r.DeleteExtState('_Slicer_', 'ItemToSlice', 0)
+    r.DeleteExtState('_Slicer_', 'TrackForSlice', 0)
+    r.SetExtState('_Slicer_', 'GetItemState', 'ItemNotLoaded', 0)
 end
 
 ClearExState()
@@ -969,6 +1099,7 @@ getitem = 1
 
 function GetTempo()
     tempo = r.Master_GetTempo()
+    tempo_corr = 1/(r.Master_GetTempo()/120)
     retoffset = (60000/tempo)/16 - 20
     retrigms = retoffset*0.00493 or 0.0555
 end
@@ -984,30 +1115,42 @@ GetTempo()
 r.PreventUIRefresh(-1); r.Undo_EndBlock('Slicer', -1)
 
 --------------------------------------------------------------------------------
----------------------Retina Check-----------------------------------------------
+---------------------Retina Check---------------------------------------------
 --------------------------------------------------------------------------------
-local retval, dpi = reaper.ThemeLayout_GetLayout("mcp", -3) -- get the current dpi
+local retval, dpi = r.ThemeLayout_GetLayout("mcp", -3) -- get the current dpi
 --Now we need to tell the gfx-functions, that Retina/HiDPI is available(512)
 if dpi == "512" then -- if dpi==retina, set the gfx.ext_retina to 1, else to 0
-  gfx.ext_retina=1 -- Retina
-else
-  gfx.ext_retina=0 -- no Retina
+   gfx.ext_retina=1 -- Retina
+   else
+   gfx.ext_retina=0 -- no Retina
 end
 ---------------------------------------------------------------
 ----------------------Rounding-------------------------------
 ---------------------------------------------------------------
 math_round = function(num, idp) -- rounding
   local mult = 10^(idp or 0)
-  return floor(num * mult + 0.5) / mult
+  return ((num * mult + 0.5)//1) / mult
 end
 ---------------------------------------------------------------
-----------------------Find Even/Odd---------------------------
+----------------------Find Even/Odd--------------------------
 ---------------------------------------------------------------
 function IsEven(num)
   return num % 2 == 0
 end
+---------------------------------------------------------------
+----------------------Text Shortener-------------------------
+---------------------------------------------------------------
+function TextShort(stext, limit) -- stext - text input, limit - number of characters
+    local symbols_count = #stext
+    if symbols_count >= limit then
+        stext = stext:sub(1, symbols_count-(symbols_count-limit))
+        else
+        stext = stext
+    end
+        return stext
+end
 --------------------------------------------------------------------------------
----   Simple Element Class   ---------------------------------------------------
+---   Simple Element Class   --------------------------------------------------
 --------------------------------------------------------------------------------
 local Element = {}
 function Element:new(x,y,w,h, r,g,b,a, lbl,fnt,fnt_sz, norm_val,norm_val2, fnt_rgba)
@@ -1025,21 +1168,21 @@ function Element:new(x,y,w,h, r,g,b,a, lbl,fnt,fnt_sz, norm_val,norm_val2, fnt_r
     return elm
 end
 
---------------------------------------------------------------
---- Function for Child Classes(args = Child,Parent Class) ----
---------------------------------------------------------------
+---------------------------------------------------------------
+--- Function for Child Classes(args = Child,Parent Class) ---
+---------------------------------------------------------------
 function extended(Child, Parent)
   setmetatable(Child,{__index = Parent}) 
 end
 --------------------------------------------------------------
----   Element Class Methods(Main Methods)   ------------------
+---   Element Class Methods(Main Methods)   -------------
 --------------------------------------------------------------
 function Element:update_xywh()
   if not Z_w or not Z_h then return end -- return if zoom not defined
-  local zoom_coeff =   (gfx_width/1000)+1
+  local zoom_coeff =   (gfx_width/1200)+1
   if zoom_coeff <= 2.044 then zoom_coeff = 2.044 end 
   self.x, self.w = (self.def_xywh[1]* Z_w/zoom_coeff)*2.045, (self.def_xywh[3]* Z_w/zoom_coeff)*2.045-- upd x,w
-  self.x = self.x+(zoom_coeff-2.044)*270 -- auto slide to right whem woom
+  self.x = self.x+(zoom_coeff-2.044)*380 -- auto slide to right when zoom
   self.x = math_round(self.x,2)
   self.w = math_round(self.w,2)
   self.y, self.h = (self.def_xywh[2]* Z_h) , (self.def_xywh[4]* Z_h) -- upd y,h
@@ -1165,9 +1308,9 @@ function Element:draw_rect_ruler()
 end
 
 ----------------------------------------------------------------------------------------------------
----   Create Element Child Classes(Button,Slider,Knob)   -------------------------------------------
+---   Create Element Child Classes(Button,Slider,Knob)   ----------------------------------------
 ----------------------------------------------------------------------------------------------------
-  local Button, Button_small, Button_top, Button_Settings, Slider, Slider_small, Slider_simple, Slider_complex, Slider_Fine, Slider_Swing, Slider_fgain, Rng_Slider, Knob, CheckBox, CheckBox_simple, CheckBox_Show, Frame, Colored_Rect, Colored_Rect_top, Frame_filled, ErrMsg, Txt, Txt2, Line, Line_colored, Line2, Ruler = {},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}
+  local Button, Button_small, Button_top, Button_Settings, Slider, Slider_small, Slider_simple, Slider_complex, Slider_Fine, Slider_Swing, Slider_fgain, Rng_Slider, Knob, CheckBox, CheckBox_simple, CheckBox_Show, Frame, Colored_Rect, Colored_Rect_top, Frame_filled, ErrMsg, SysMsg, Txt, Txt2, Line, Line_colored, Line2, Ruler = {},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}
   extended(Button,     Element)
   extended(Button_small,     Element)
   extended(Button_top,     Element)
@@ -1181,6 +1324,7 @@ end
   extended(Slider_Swing,     Element)
   extended(Slider_fgain,     Element)
   extended(ErrMsg,     Element)
+  extended(SysMsg,     Element)
   extended(Txt,     Element)
   extended(Txt2,     Element)
   extended(Line,     Element)
@@ -1216,7 +1360,7 @@ end
   extended(CheckBox_Show,   Element)
  
 --------------------------------------------------------------------------------
----   Buttons Class Methods   ---------------------------------------------------
+---   Buttons Class Methods   ------------------------------------------------
 --------------------------------------------------------------------------------
 function Button_small:draw_body()
     gfx.rect(self.x+1,self.y+1,self.w-2,self.h-2,true) -- draw btn body
@@ -1436,12 +1580,74 @@ end
 ---   ErrMsg Class Methods   ---------------------------------------------------
 --------------------------------------------------------------------------------
 function ErrMsg:draw()
-    self:update_xywh() -- Update xywh(if wind changed)
-    local x,y,w,h  = self.x,self.y,self.w,self.h
+  if not Z_w or not Z_h then return end -- return if zoom not defined
+  self.x, self.w = (self.def_xywh[1]* Z_w) , (self.def_xywh[3]* Z_w) -- upd x,w
+  self.y, self.h = (self.def_xywh[2]* Z_h) , (self.def_xywh[4]* Z_h) -- upd y,h
+
+    local r,g,b,a  = self.r,self.g,self.b,self.a
+    local x,y,w,h  = self.x,self.y/6,self.w,self.h
     local lbl_w, lbl_h = gfx.measurestr(self.lbl)
-    gfx.x = x+(w-lbl_w)/2; gfx.y = y+(h-lbl_h)/2
-    gfx.set(0.8, 0.3, 0.3, 1)   -- set label color
-    gfx.drawstr(self.lbl)
+         gfx.x = x+(w-lbl_w)/3.5
+         gfx.y = (y+(h-lbl_h)/50)-5
+
+  local  fnt_sz = 0
+
+        if fnt_sz < 16 then fnt_sz = 16 end
+        if fnt_sz > 22 then fnt_sz = 22 end
+
+        fnt_sz = fnt_sz*(Z_h*1.05)
+        gfx.setfont(1, "Arial", fnt_sz)
+
+    gfx.set(1, 1, 1, 0.5) -- цвет текста 
+        gfx.drawstr(self.lbl, 0|4, 900*Z_w, (50/(Z_h*8))+(22*Z_h))
+
+end
+----------------------SysMsg-----------------------------------------------------
+
+function SysMsg:draw()
+  if not Z_w or not Z_h then return end -- return if zoom not defined
+  self.x, self.w = (self.def_xywh[1]* Z_w) , (self.def_xywh[3]* Z_w) -- upd x,w
+  self.y, self.h = (self.def_xywh[2]* Z_h) , (self.def_xywh[4]* Z_h) -- upd y,h
+
+    local r,g,b,a  = self.r,self.g,self.b,self.a
+    local x,y,w,h  = self.x,self.y/6,self.w,self.h
+    local lbl_w, lbl_h = gfx.measurestr(self.lbl)
+         gfx.x = x+(w-lbl_w)/3.5
+         gfx.y = (y+(h-lbl_h)/50)-2
+
+     local xc = 0
+     local  fnt_sz = 0
+     local symbols_count = #TableTI.item
+     if symbols_count >= 50 then -- sc limit
+         symbols_count = symbols_count-(symbols_count-50)
+     end
+
+      if  Swing_on == 1 then 
+         xc = 100*Z_w  
+          else
+         xc = 0 
+      end
+
+      if fnt_sz < 16 then fnt_sz = 16 end
+      if fnt_sz > 22 then fnt_sz = 22 end
+
+      fnt_sz = fnt_sz*(Z_h*1.05)
+      gfx.setfont(1, "Arial", fnt_sz)
+
+      gfx.x = gfx.x-(fnt_sz*4)
+
+      if symbols_count > 20 then
+          if gfx.x < (35-(symbols_count/4))*(fnt_sz*2) then 
+          gfx.x = xc+450*Z_w 
+          else
+            if fnt_sz > 20 and Swing_on == 0 then
+              gfx.x = gfx.x-(fnt_sz*4)
+            end
+          end
+      end
+
+    gfx.set(1, 1, 1, 0.5) -- цвет текста 
+        gfx.drawstr(self.lbl, 0|4, 900*Z_w, (50/(Z_h*8))+(22*Z_h))
 end
 
 --------------------------------------------------------------------------------
@@ -1494,8 +1700,8 @@ function Slider_complex:set_norm_val_m_wheel()
     end
     local Step = Mult_S
     if gfx.mouse_wheel == 0 then return false end  -- return if m_wheel = 0
-    if gfx.mouse_wheel > 0 then self.norm_val = min(self.norm_val+Step, 1) end
-    if gfx.mouse_wheel < 0 then self.norm_val = max(self.norm_val-Step, 0) end
+    if gfx.mouse_wheel > 0 then self.norm_val = min(self.norm_val+Step, 1)end
+    if gfx.mouse_wheel < 0 then self.norm_val = max(self.norm_val-Step, 0)end
     return true
 end
 
@@ -1537,6 +1743,7 @@ function Slider_fgain:set_norm_val_m_wheel()
     if gfx.mouse_wheel < 0 then self.norm_val = max(self.norm_val-Step, 0) end
     return true
 end
+
 -------------------------------------------------------------------------------------
 function H_Slider:set_norm_val()
     local x, w = self.x, self.w
@@ -1694,6 +1901,7 @@ function X_SliderOff:set_norm_val()
     VAL = 0
     self.norm_val=VAL
 end
+
 -----------------------------------------------------------------------------
 function H_Slider:draw_body()
     local x,y,w,h  = self.x,self.y,self.w,self.h
@@ -2018,12 +2226,12 @@ if fnt_sz >= 18 then fnt_sz = 18 end
             if timer2 < 0.15 then timer2 = timer2/1.4 end
             if timer2 < 0.10 then timer2 = timer2/8 end
         local function Main_Timer() -- timer prevents slider lag
-           if elapsed ~= 1 then
+           if elapsed ~= timer2 then
                   elapsed = reaper.time_precise() - time_start
                  if elapsed >= timer2 then   
                      runcheck = 0
                      if gfx.mouse_wheel == 0 then 
-                        MW_doit_slider() --------- main function
+                        MW_doit_slider(1) --------- main function
                      end
                      return
                  else
@@ -2122,12 +2330,12 @@ if fnt_sz >= 18 then fnt_sz = 18 end
             if timer2 < 0.15 then timer2 = timer2/1.4 end
             if timer2 < 0.10 then timer2 = timer2/8 end
         local function Main_Timer() -- timer prevents slider lag
-           if elapsed ~= 1 then
+           if elapsed ~= timer2 then
                   elapsed = reaper.time_precise() - time_start
                  if elapsed >= timer2 then   
                      runcheck = 0
                      if gfx.mouse_wheel == 0 then 
-                        MW_doit_slider_Fine()  --------- main function
+                        MW_doit_slider_Fine(1)  --------- main function
                      end
                      return
                  else
@@ -2232,22 +2440,22 @@ if fnt_sz >= 18 then fnt_sz = 18 end
             if timer2 < 0.15 then timer2 = timer2/1.2 end
             if timer2 < 0.10 then timer2 = timer2/4 end
         local function Main_Timer() -- timer prevents slider lag
-           if elapsed ~= 1 then
+           if elapsed ~= timer2 then
                   elapsed = reaper.time_precise() - time_start
                  if elapsed >= timer2 then   
-                     runcheck = 0
+                     runcheck_c = 0
                      if gfx.mouse_wheel == 0 then 
-                          MW_doit_slider_comlpex()  --------- main function
+                          MW_doit_slider_comlpex(1)  --------- main function
                      end
                      return
                  else
-                 runcheck = 1 
+                 runcheck_c = 1 
                      reaper.defer(Main_Timer)
                  end
             end
          end
              
-       if runcheck ~= 1 then
+       if runcheck_c ~= 1 then
            Main_Timer()
        end
  ---------------------------------------------------------
@@ -2296,12 +2504,12 @@ if fnt_sz >= 18 then fnt_sz = 18 end
             if timer2 < 0.15 then timer2 = timer2/1.4 end
             if timer2 < 0.10 then timer2 = timer2/8 end
         local function Main_Timer() -- timer prevents slider lag
-           if elapsed ~= 1 then
+           if elapsed ~= timer2 then
                   elapsed = reaper.time_precise() - time_start
                  if elapsed >= timer2 then   
                      runcheck = 0
                      if gfx.mouse_wheel == 0 then 
-                           MW_doit_slider_fgain()   --------- main function
+                           MW_doit_slider_fgain(1)   --------- main function
                      end
                      return
                  else
@@ -2341,7 +2549,7 @@ if fnt_sz >= 18 then fnt_sz = 18 end
 end
 
 --------------------------------------------------------------------------------
----   Rng_Slider Class Methods   -----------------------------------------------
+---   Rng_Slider Class Methods   ---------------------------------------------
 --------------------------------------------------------------------------------
 function Rng_Slider:set_norm_val_m_wheel()
     if Shift == true then
@@ -2489,7 +2697,7 @@ if fnt_sz >= 18 then fnt_sz = 18 end
     -- set additional coordinates --
  --   self.sb_w  = h-5
  --   self.sb_w  = floor(self.w/17) -- sidebuttons width(change it if need)
-    self.sb_w  = floor(self.w/10) -- sidebuttons width(change it if need)
+    self.sb_w  = self.w//10 -- sidebuttons width(change it if need)
     self.rng_x = self.x + self.sb_w    -- range streak min x
     self.rng_w = self.w - self.sb_w*2  -- range streak max w
     -- Get mouse state -------------
@@ -2538,7 +2746,7 @@ if fnt_sz >= 18 then fnt_sz = 18 end
 end
 
 --------------------------------------------------------------------------------
----   Loop_Slider Class Methods   -----------------------------------------------
+---   Loop_Slider Class Methods   --------------------------------------------
 --------------------------------------------------------------------------------
 
 function Loop_Slider:set_norm_val_m_wheel()
@@ -2743,7 +2951,7 @@ end
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
----   CheckBox Class Methods   -------------------------------------------------
+---   CheckBox Class Methods   ----------------------------------------------
 --------------------------------------------------------------------------------
 function CheckBox:set_norm_val_m_wheel()
     if gfx.mouse_wheel == 0 then return false end  -- return if m_wheel = 0
@@ -2974,7 +3182,7 @@ if fnt_sz >= 18 then fnt_sz = 18 end
 end
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
----   Frame Class Methods  -----------------------------------------------------
+---   Frame Class Methods  --------------------------------------------------
 --------------------------------------------------------------------------------
 function Frame:draw()
    self:update_xywh() -- Update xywh(if wind changed)
@@ -2984,7 +3192,7 @@ function Frame:draw()
 end
 
 --------------------------------------------------------------------------------
----   Frame Class Methods  -----------------------------------------------------
+---   Frame Class Methods  --------------------------------------------------
 --------------------------------------------------------------------------------
 function Colored_Rect:draw()
    self:update_xywh() -- Update xywh(if wind changed)
@@ -3004,7 +3212,7 @@ function Colored_Rect_top:draw()
 end
 
 --------------------------------------------------------------------------------
----   Frame_filled Class Methods  -----------------------------------------------------
+---   Frame_filled Class Methods  --------------------------------------------
 --------------------------------------------------------------------------------
 function Frame_filled:draw()
    self:update_xywh() -- Update xywh(if wind changed)
@@ -3014,65 +3222,64 @@ function Frame_filled:draw()
 end
 
 ----------------------------------------------------------------------------------------------------
---   Some Default Values   -------------------------------------------------------------------------
+--   Some Default Values   -----------------------------------------------------------------------
 ----------------------------------------------------------------------------------------------------
 
 function Init_Srate()
 
 local init_item = r.GetSelectedMediaItem(0,0)
 
- if init_item  then
-       local init_take = r.GetActiveTake(init_item)
-       local item = r.GetMediaItemTake_Item(init_take) -- Get parent item
-   if item == nil then
-     return
-   end
-
-   -- Get media source of media item take
-   local take_pcm_source = r.GetMediaItemTake_Source(init_take)
-   if take_pcm_source == nil then
-     return
-   end
-   local srate = r.GetMediaSourceSampleRate(take_pcm_source)
-end
-
-   if srate then
-      if srate < 44100 then srate = 44100 end
-      if srate > 48000 then srate = 48000 end
-    else
-      srate = 44100
-   end
+      if init_item  then
+            local init_take = r.GetActiveTake(init_item)
+               if init_take ~= nil then 
+              
+                  -- Get media source of media item take
+                  local take_pcm_source = r.GetMediaItemTake_Source(init_take)
+                  if take_pcm_source == nil then 
+                     local srate = 44100
+                  else
+                     local srate = r.GetMediaSourceSampleRate(take_pcm_source)
+                  end
+              end    
+     
+                  if srate then
+                     if srate < 44100 then srate = 44100 end
+                     if srate > 48000 then srate = 48000 end
+                   else
+                     srate = 44100
+                  end
+       end
 end
 
 Init_Srate() -- Project Samplerate
+
 
 local block_size = 1024*16 -- размер блока(для фильтра и тп) , don't change it!
 local time_limit = 5*60    -- limit maximum time, change, if need.
 local defPPQ = 960         -- change, if need.
 ----------------------------------------------------------------------------------------------------
----  Create main objects(Wave,Gate) ----------------------------------------------------------------
+---  Create main objects(Wave,Gate) -----------------------------------------------------------
 ----------------------------------------------------------------------------------------------------
 local Wave = Element:new(10,45,1024,335)
 local Gate_Gl  = {}
 
-corrX = 0
 corrY = 10
-corrY2 = 3 -- Random_Setup menu correction
-  
+corrY3 = 16 -- MIDI Elements Shift
+
 ---------------------------------------------------------------
----  Create Frames   ------------------------------------------
+---  Create Frames ------------------------------------------
 ---------------------------------------------------------------
 ------local tables to reduce locals (avoid 200 locals limits)-------
-local elm_table = {Fltr_Frame, Gate_Frame, Mode_Frame, Mode_Frame_filled, Gate_Frame_filled, Random_Setup_Frame_filled, Random_Setup_Frame, Grid1_Led, Grid2_Led, Grid4_Led, Grid8_Led, Grid16_Led, Grid32_Led, Grid64_Led, GridT_Led, Swing_Led}
+local elm_table = {Fltr_Frame, Gate_Frame, Mode_Frame, Mode_Frame_filled, Gate_Frame_filled, Random_Setup_Frame_filled, Random_Setup_Frame, Grid1_Led, Grid2_Led, Grid4_Led, Grid8_Led, Grid16_Led, Grid32_Led, Grid64_Led, GridT_Led, Swing_Led, MIDI_Divider_Line, MIDI_Divider_Line2}
 
 elm_table[1] = Frame:new(10, 375+corrY,180,100) --Fltr_Frame
 elm_table[2] = Frame:new(200,375+corrY,180,100) --Gate_Frame
 elm_table[3] = Frame:new(390,375+corrY,645,100) --Mode_Frame
-elm_table[4] = Frame_filled:new(670,380+corrY,191,69,  0.2,0.2,0.2,0.5 ) --Mode_Frame_filled
+elm_table[4] = Frame_filled:new(685,380+corrY,279,69,  0.2,0.2,0.2,0.5 ) --Mode_Frame_filled
 elm_table[5] = Frame_filled:new(210,380+corrY,160,89,  0.2,0.2,0.2,0.5 ) --Gate_Frame_filled
 
-elm_table[6] = Frame_filled:new(670,373+corrY2,147,112,  0.15,0.15,0.15,1 ) --Random_Setup_Frame_filled
-elm_table[7] = Frame:new(670,373+corrY2,147,112,  0.15,0.15,0.15,1 ) --Random_Setup_Frame
+elm_table[6] = Frame_filled:new(670,376,147,112,  0.15,0.15,0.15,1 ) --Random_Setup_Frame_filled
+elm_table[7] = Frame:new(670,376,147,112,  0.15,0.15,0.15,1 ) --Random_Setup_Frame
 
 elm_table[8] = Colored_Rect_top:new(50,24,40,2,  0.0,0.7,0.0,1 ) -- Grid1_Led
 elm_table[9] = Colored_Rect_top:new(92,24,40,2,  0.0,0.7,0.0,1 ) -- Grid2_Led
@@ -3084,7 +3291,10 @@ elm_table[14] = Colored_Rect_top:new(302,24,40,2,  0.0,0.7,0.0,1 ) -- Grid64_Led
 elm_table[15] = Colored_Rect_top:new(344,24,40,2,  0.0,0.7,0.0,1 ) -- GridT_Led
 elm_table[16] = Colored_Rect_top:new(391,24,50,2,  0.0,0.7,0.0,1 ) -- Swing_Led
 
-local leds_table = {Frame_byGrid, Frame_byGrid2, Light_Loop_on, Light_Loop_off, Light_Sync_on, Light_Sync_off, Rand_Mode_Color1, Rand_Mode_Color2, Rand_Mode_Color3, Rand_Mode_Color4, Rand_Mode_Color5, Rand_Mode_Color6, Rand_Mode_Color7, Rand_Button_Color1, Rand_Button_Color2, Rand_Button_Color3, Rand_Button_Color4, Rand_Button_Color5, Rand_Button_Color6, Rand_Button_Color7}
+elm_table[17] = Line2:new(675,380+corrY,4,88,0.3,0.3,0.3,0.5) -- Vertical Line 
+elm_table[18] = Line2:new(676,380+corrY,4,88,0.177,0.177,0.177,1)--| fill
+
+local leds_table = {Frame_byGrid, Frame_byGrid2, Light_Loop_on, Light_Loop_off, Light_Sync_on, Light_Sync_off, Rand_Mode_Color1, Rand_Mode_Color2, Rand_Mode_Color3, Rand_Mode_Color4, Rand_Mode_Color5, Rand_Mode_Color6, Rand_Mode_Color7, Rand_Button_Color1, Rand_Button_Color2, Rand_Button_Color3, Rand_Button_Color4, Rand_Button_Color5, Rand_Button_Color6, Rand_Button_Color7, MIDIMode1, MIDIMode2, MIDIMode3}
 
 leds_table[1] = Colored_Rect:new(591,410+corrY,2,18,  0.1,0.7,0.6,1 ) -- Frame_byGrid (Blue indicator)
 leds_table[2] = Colored_Rect:new(591,410+corrY,2,18,  0.7,0.7,0.0,1 ) -- Frame_byGrid2 (Yellow indicator)
@@ -3095,13 +3305,13 @@ leds_table[4] = Colored_Rect_top:new(981,5,2,20,  0.5,0.5,0.5,0.5 ) -- Light_Loo
 leds_table[5] = Colored_Rect_top:new(921,5,2,20,  0.0,0.7,0.0,1 ) -- Light_Sync_on
 leds_table[6] = Colored_Rect_top:new(921,5,2,20,  0.5,0.5,0.5,0.5 ) -- Light_Sync_off
 
-leds_table[7] = Colored_Rect:new(675,377+corrY2,2,14,  0.1,0.8,0.2,1 ) --  Rand_Mode_Color1
-leds_table[8] = Colored_Rect:new(675,392+corrY2,2,14,  0.7,0.7,0.0,1 ) --  Rand_Mode_Color2
-leds_table[9] = Colored_Rect:new(675,407+corrY2,2,14,  0.8,0.4,0.1,1 ) --  Rand_Mode_Color3
-leds_table[10] = Colored_Rect:new(675,422+corrY2,2,14,  0.7,0.0,0.0,1 ) --  Rand_Mode_Color4
-leds_table[11] = Colored_Rect:new(675,452+corrY2,2,14,  0.2,0.5,1,1 ) --  Rand_Mode_Color5
-leds_table[12] = Colored_Rect:new(675,437+corrY2,2,14,  0.8,0.1,0.8,1 ) --  Rand_Mode_Color6
-leds_table[13] = Colored_Rect:new(675,467+corrY2,2,14,  0.1,0.7,0.6,1 ) --  Rand_Mode_Color7
+leds_table[7] = Colored_Rect:new(675,380,2,14,  0.1,0.8,0.2,1 ) --  Rand_Mode_Color1
+leds_table[8] = Colored_Rect:new(675,395,2,14,  0.7,0.7,0.0,1 ) --  Rand_Mode_Color2
+leds_table[9] = Colored_Rect:new(675,410,2,14,  0.8,0.4,0.1,1 ) --  Rand_Mode_Color3
+leds_table[10] = Colored_Rect:new(675,425,2,14,  0.7,0.0,0.0,1 ) --  Rand_Mode_Color4
+leds_table[11] = Colored_Rect:new(675,455,2,14,  0.2,0.5,1,1 ) --  Rand_Mode_Color5
+leds_table[12] = Colored_Rect:new(675,440,2,14,  0.8,0.1,0.8,1 ) --  Rand_Mode_Color6
+leds_table[13] = Colored_Rect:new(675,470,2,14,  0.1,0.7,0.6,1 ) --  Rand_Mode_Color7
 
 leds_table[14] = Colored_Rect:new(598,436,8,2,  0.1,0.8,0.2,1 ) --  Rand_Button_Color1
 leds_table[15] = Colored_Rect:new(607,436,9,2,  0.7,0.7,0.0,1 ) --  Rand_Button_Color2
@@ -3111,25 +3321,36 @@ leds_table[18] = Colored_Rect:new(647,436,9,2,  0.2,0.5,1,1 ) --  Rand_Button_Co
 leds_table[19] = Colored_Rect:new(637,436,9,2,  0.8,0.1,0.8,1 ) --  Rand_Button_Color6
 leds_table[20] = Colored_Rect:new(657,436,8,2,  0.1,0.7,0.6,1 ) --  Rand_Button_Color7
 
-local others_table = {Triangle, RandText, Q_Rnd_Linked, Q_Rnd_Linked2, Line, Line2, Loop_Dis, Ruler}
+leds_table[21] = Colored_Rect:new(766+corrY3,410+corrY,2,18,  0.69,0.17,0.17,1 ) -- MIDIMode1
+leds_table[22] = Colored_Rect:new(766+corrY3,410+corrY,2,18,  0.69,0.32,0.05,1 ) -- MIDIMode2
+leds_table[23] = Colored_Rect:new(766+corrY3,410+corrY,2,18,  0.54,0.14,1,1 ) -- MIDIMode3
 
-others_table[1] = Txt2:new(642,415+corrY2,55,18, 0.4,0.4,0.4,1, ">","Arial",20) --Triangle
-others_table[2] = Txt2:new(749,374+corrY2,55,18, 0.4,0.4,0.4,1, "Intensity","Arial",10) --RandText
+
+local others_table = {Triangle, RandText, Q_Rnd_Linked, Q_Rnd_Linked2, Line, Line2, Loop_Dis, Ruler, Preset, Velocity, Mode, Mode2, ModeText}
+
+others_table[1] = Txt2:new(642,418,55,18, 0.4,0.4,0.4,1, ">","Arial",20) --Triangle
+others_table[2] = Txt2:new(749,377,55,18, 0.4,0.4,0.4,1, "Intensity","Arial",10) --RandText
 
 others_table[3] = Line_colored:new(482,375+corrY,152,18,  0.7,0.5,0.1,1) --| Q_Rnd_Linked (Bracket)
 others_table[4] = Line2:new(480,380+corrY,156,18,  0.177,0.177,0.177,1)--| Q_Rnd_Linked2 (Bracket fill)
 
-others_table[5] = Line:new(774,404+corrY,82,6) --Line (Preset/Velocity Bracket)
-others_table[6] = Line2:new(774,407+corrY,82,4,  0.177,0.177,0.177,1)--Line2 (Preset/Velocity Bracket fill)
+others_table[5] = Line:new(774+corrY3,404+corrY,82,6) --Line (Preset/Velocity Bracket)
+others_table[6] = Line2:new(774+corrY3,407+corrY,82,4,  0.177,0.177,0.177,1)--Line2 (Preset/Velocity Bracket fill)
 others_table[7] = Colored_Rect_top:new(10,28,1024,15,  0.23,0.23,0.23,0.5)--Loop_Dis (Loop Disable fill)
 others_table[8] = Ruler:new(10,42,1024,13,  0,0,0,0)--Loop_Dis (Loop Disable fill)
 
+others_table[9] = Txt:new(788+corrY3,384+corrY,55,18, 0.8,0.8,0.8,0.8, "Preset","Arial",22)
+others_table[10] = Txt:new(788+corrY3,384+corrY,55,18, 0.8,0.8,0.8,0.8, "Velocity","Arial",22)
+
+others_table[11] = Line:new(866+corrY3,404+corrY,78,6) --Line (Mode Bracket)
+others_table[12] = Line2:new(866+corrY3,407+corrY,78,4,  0.177,0.177,0.177,1)--Line2 (Mode Bracket fill)
+others_table[13] = Txt:new(878+corrY3,384+corrY,55,18, 0.8,0.8,0.8,0.8, "Mode","Arial",22) -- Mode Text
 
 local Frame_Sync_TB = {leds_table[5]}
 local Frame_Sync_TB2 = {leds_table[6]}
 local Frame_Loop_TB = {leds_table[3]}
 local Frame_Loop_TB2 = {leds_table[4], others_table[7]}
-local Frame_TB = {elm_table[1], elm_table[2], elm_table[3]} 
+local Frame_TB = {elm_table[1], elm_table[2], elm_table[3], elm_table[17], elm_table[18]} 
 local FrameR_TB = {others_table[5], others_table[6]}
 local FrameQR_Link_TB = {others_table[3],others_table[4]}
 local Frame_TB1 = {leds_table[2]}
@@ -3165,12 +3386,40 @@ local Rand_Button_Color7_TB = {leds_table[20]}
 local Triangle_TB = {others_table[1]}
 local RandText_TB = {others_table[2]}
 local Ruler_TB = {others_table[8]}
+local Preset_TB = {others_table[9]}  
 
-local Midi_Sampler = CheckBox_simple:new(670,410+corrY,98,18, 0.28,0.4,0.7,0.8, "","Arial",16,  MIDI_Mode,
-                              {"Sampler","Trigger"} )
+local MIDI_Mode_Color1_TB = {leds_table[21]}
+local MIDI_Mode_Color2_TB = {leds_table[22]}
+local MIDI_Mode_Color3_TB = {leds_table[23]}
 
-local Sampler_preset = CheckBox_simple:new(770,410+corrY,90,18, 0.28,0.4,0.7,0.8, "","Arial",16,  Sampler_preset_state,
+
+
+local Midi_Sampler = CheckBox_simple:new(670+corrY3,410+corrY,96,18, 0.28,0.4,0.7,0.8, "","Arial",16,  MIDI_Mode,
+                              {"Sampler","Trigger","Pitch Detect"} )
+
+if Midi_Sampler.norm_val == 3 and RebuildPeaksOnStart == 1 then
+    r.Main_OnCommand(40441,0) --rebuild peaks when the script starts
+end
+
+local Sampler_preset = CheckBox_simple:new(770+corrY3,410+corrY,90,18, 0.28,0.4,0.7,0.8, "","Arial",16,  Sampler_preset_state,
                               {"Percussive","Melodic"} )
+
+local Pitch_Preset = CheckBox_simple:new(770+corrY3,410+corrY,90,18, 0.28,0.4,0.7,0.8, "","Arial",16,  PitchDetect,
+                              {"Drums","Drums 2", "Percussion", "Bass","Default","Melodic","Complex"} )
+
+
+local Pitch_Det_Options = CheckBox_simple:new(670+corrY3,430+corrY,98,18, 0.28,0.4,0.7,0.8, "","Arial",16,  Pitch_Det_Options_state,
+                              {"Velocity On","Velocity Off"} )
+
+local Pitch_Det_Options2 = CheckBox_simple:new(670+corrY3,450+corrY,98,18, 0.28,0.4,0.7,0.8, "","Arial",16,  Pitch_Det_Options_state2,
+                              {"Note Lgth.","Staccato","Legato"} )
+
+local Create_Replace = CheckBox_simple:new(862+corrY3,410+corrY,86,18, 0.28,0.4,0.7,0.8, "","Arial",16,  Create_Replace_state,
+                              {"Create","Replace"} )
+
+local VeloMode = CheckBox_simple:new(770+corrY3,410+corrY,90,18, 0.28,0.4,0.7,0.8, "","Arial",16,  1, -------velodaw
+                              {"Use RMS","Use Peak"} )
+
 
 ---------------------------------------------------------------
 ---  Create Menu Settings   ------------------------------------
@@ -3346,18 +3595,18 @@ end
 
 
 ----------------------------------------------------------------------------------------------------
----  Create controls objects(btns,sliders etc) and override some methods   -------------------------
+---  Create controls objects(btns,sliders etc) and override some methods   ------------------------
 ----------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------
+-----------------------------------------------------------------------------------
 --- Filter Sliders ------------------------------------------------------------------
--------------------------------------------------------------------------------------
+-----------------------------------------------------------------------------------
 -- Filter HP_Freq --------------------------------
 local HP_Freq = HP_Slider:new(20,410+corrY,160,18, 0.28,0.4,0.7,0.8, "Low Cut","Arial",16, HF_Slider )
 -- Filter LP_Freq --------------------------------
 local LP_Freq = LP_Slider:new(20,430+corrY,160,18, 0.28,0.4,0.7,0.8, "High Cut","Arial",16, LF_Slider )
---------------------------------------------------
+------------------------------------------------
 -- Filter Freq Sliders draw_val function ---------
---------------------------------------------------
+------------------------------------------------
 function HP_Freq:draw_val()
 if LP_Freq.norm_val <= HP_Freq.norm_val+0.05 then LP_Freq.norm_val = HP_Freq.norm_val+0.05 end --auto "bell"
 if HP_Freq.norm_val <= 0 then HP_Freq.norm_val = 0 end
@@ -3366,12 +3615,15 @@ if LP_Freq.norm_val >= 1 then LP_Freq.norm_val = 1 end
 if LP_Freq.norm_val <= 0 then LP_Freq.norm_val = 0 end
   local sx = 16+(self.norm_val*100)*1.20103
   self.form_val = floor(exp(sx*logx(1.059))*8.17742) -- form val
+
+if self.form_val > 20000 then self.form_val = 20000 end
   -------------
   local x,y,w,h  = self.x,self.y,self.w,self.h
   local val = string.format("%d", self.form_val) .." Hz"
   local val_w, val_h = gfx.measurestr(val)
   gfx.x = x+w-val_w-3
   gfx.drawstr(val) -- draw Slider Value
+  if self.form_val == 20 then self.form_val = 0 end -- filter off
 end
 -------------------------
 function LP_Freq:draw_val()
@@ -3398,44 +3650,34 @@ function Fltr_Gain:draw_val()
   gfx.drawstr(val)--draw Slider Value
 end
 
---------------------------------------------------
+------------------------------------------------
 -- onUp function for Filter Freq sliders ---------
---------------------------------------------------
+------------------------------------------------
 function Fltr_Sldrs_onUp()
-   if Wave.AA then Wave:Processing()
+   if Wave.AA then 
       if Wave.State then
-         Wave:Redraw() 
-         Gate_Gl:Apply_toFiltered()
+         MW_doit_slider_comlpex()
       end
    end
 end
 ----------------
 HP_Freq.onUp   = Fltr_Sldrs_onUp
 LP_Freq.onUp   = Fltr_Sldrs_onUp
---------------------------------------------------
+------------------------------------------------
 -- onUp function for Filter Gain slider  ---------
---------------------------------------------------
+------------------------------------------------
 Fltr_Gain.onUp =
 function() 
    if Wave.State then 
-      Wave:Redraw()
-      Gate_Gl:Apply_toFiltered() 
+      MW_doit_slider_fgain()
    end 
-end
-
--------------------------
-local VeloMode = CheckBox_simple:new(770,410+corrY,90,18, 0.28,0.4,0.7,0.8, "","Arial",16,  1, -------velodaw
-                              {"Use RMS","Use Peak"} )
-
-VeloMode.onClick = 
-function()
 end
 
 -------------------------------------------------------------------------------------
 --- Gate Sliders --------------------------------------------------------------------
 -------------------------------------------------------------------------------------
--- Threshold -------------------------------------
--------------------------------------------------
+-- Threshold -----------------------------------
+------------------------------------------------
 local Gate_Thresh = T_Slider:new(210,380+corrY,160,18, 0.28,0.4,0.7,0.8, "Threshold","Arial",16, readrms )
 function Gate_Thresh:draw_val()
   self.form_val = (self.norm_val-1)*57-3
@@ -3502,7 +3744,7 @@ end
 -- onUp function for Gate sliders(except reduce) -
 --------------------------------------------------
 function Gate_Sldrs_onUp() 
-   if Wave.State then Gate_Gl:Apply_toFiltered() end 
+   if Wave.State then MW_doit_slider() end 
 end
 ----------------
 Gate_Thresh.onUp    = Gate_Sldrs_onUp
@@ -3527,13 +3769,14 @@ function Offset_Sld:draw_val()
   local val_w, val_h = gfx.measurestr(val)
   gfx.x = x+w-val_w-3
   gfx.drawstr(val)--draw Slider Value
-  
+  Offset_Sld.form_val = Offset_Sld.form_val-0.5 -- correction
   end
 Offset_Sld.onUp =
 function() 
    if Wave.State then
-      Gate_Gl:Apply_toFiltered()
-      DrawGridGuides()
+
+      MW_doit_slider_Fine()
+
       fixzero() 
    end 
 end
@@ -3563,7 +3806,7 @@ function XFade_Sld:draw_val()
   local val_w, val_h = gfx.measurestr(val)
   gfx.x = x+w-val_w-3
   gfx.drawstr(val)--draw Slider Value
-  x_fade =  floor(XFade_Sld.form_val)
+  CrossfadeT =  floor(XFade_Sld.form_val)
 end
 XFade_Sld.onUp =
 function() 
@@ -3588,7 +3831,7 @@ end
 
 
 -- RandV_Sld ------------------------------ 
-local RandV_Sld = H_Slider:new(737,392+corrY2,75,14, 0.28,0.4,0.7,0.8, "","Arial",16, RandV )
+local RandV_Sld = H_Slider:new(737,395,75,14, 0.28,0.4,0.7,0.8, "","Arial",16, RandV )
 function RandV_Sld:draw_val()
   self.form_val = (self.norm_val)*100       -- form_val
   local x,y,w,h  = self.x,self.y,self.w,self.h
@@ -3606,7 +3849,7 @@ end
 if RandVval == nil then RandVval = RandV*100 end
 
 -- RandPan_Sld ------------------------------ 
-local RandPan_Sld = H_Slider:new(737,407+corrY2,75,14, 0.28,0.4,0.7,0.8, "","Arial",16, RandPan )
+local RandPan_Sld = H_Slider:new(737,410,75,14, 0.28,0.4,0.7,0.8, "","Arial",16, RandPan )
 function RandPan_Sld:draw_val()
   self.form_val = (self.norm_val)*100       -- form_val
   local x,y,w,h  = self.x,self.y,self.w,self.h
@@ -3624,7 +3867,7 @@ end
 if RandPanval == nil then RandPanval = RandPan*100 end
 
 -- RandPtch_Sld ------------------------------ 
-local RandPtch_Sld = H_Slider:new(737,422+corrY2,75,14, 0.28,0.4,0.7,0.8, "","Arial",16, RandPtch )
+local RandPtch_Sld = H_Slider:new(737,425,75,14, 0.28,0.4,0.7,0.8, "","Arial",16, RandPtch )
 function RandPtch_Sld:draw_val()
   self.form_val = (self.norm_val)*100       -- form_val
   local x,y,w,h  = self.x,self.y,self.w,self.h
@@ -3642,7 +3885,7 @@ end
 if RandPtchval == nil then RandPtchval = RandPtch*12 end
 
 -- RandPos_Sld ------------------------------ 
-local RandPos_Sld = H_Slider:new(737,437+corrY2,75,14, 0.28,0.4,0.7,0.8, "","Arial",16, RandPos )
+local RandPos_Sld = H_Slider:new(737,440,75,14, 0.28,0.4,0.7,0.8, "","Arial",16, RandPos )
 function RandPos_Sld:draw_val()
   self.form_val = (self.norm_val)*100       -- form_val
   local x,y,w,h  = self.x,self.y,self.w,self.h
@@ -3661,7 +3904,7 @@ end
 if RandPosval == nil then RandPosval = RandPos*100 end
 
 -- RandRev_Sld ------------------------------ 
-local RandRev_Sld = H_Slider:new(737,452+corrY2,75,14, 0.28,0.4,0.7,0.8, "","Arial",16, RandMute )
+local RandRev_Sld = H_Slider:new(737,455,75,14, 0.28,0.4,0.7,0.8, "","Arial",16, RandMute )
 function RandRev_Sld:draw_val()
   self.form_val = (self.norm_val)*100       -- form_val
   local x,y,w,h  = self.x,self.y,self.w,self.h
@@ -3671,7 +3914,7 @@ function RandRev_Sld:draw_val()
   gfx.y = y+(h-val_h)/2
   gfx.drawstr(val)--draw Slider Value
 
-  revsld =       (logx(RandRev_Sld.form_val+1))*21.63          --(RandRev_Sld.form_val/1.75)+40
+  revsld =       (logx(RandRev_Sld.form_val+1))*21.63     
   RandRevVal =  ceil(revsld*-1)+100
 end
 RandRev_Sld.onUp =
@@ -3683,7 +3926,7 @@ if RandRevVal == nil then RandRevVal = RandMute*100 end
 -------------------------------------------------------------------------------------
 --- Range Slider --------------------------------------------------------------------
 -------------------------------------------------------------------------------------
-local Gate_VeloScale = Rng_Slider:new(770,430+corrY,90,18, 0.28,0.4,0.7,0.8, "Range","Arial",16, VeloRng, VeloRng2 )---velodaw 
+local Gate_VeloScale = Rng_Slider:new(770+corrY3,430+corrY,90,18, 0.28,0.4,0.7,0.8, "Range","Arial",16, VeloRng, VeloRng2 )---velodaw 
 function Gate_VeloScale:draw_val()
 
   self.form_val  = floor(1+ self.norm_val * 126)  -- form_val
@@ -3968,7 +4211,7 @@ function Swing_Sld:draw_val()
   local val_w, val_h = gfx.measurestr(val)
   gfx.x = x+w-val_w-3
   gfx.drawstr(val)--draw Slider Value
-  swing_slider_amont = self_form_val/100
+  swing_slider_amont = math_round(self_form_val/100, 2)
   end
 Swing_Sld.onUp =
 function() 
@@ -3986,7 +4229,7 @@ Trigger_Oct_Shift = tonumber(r.GetExtState('cool_MK Slicer.lua','Trigger_Oct_Shi
 octa = Trigger_Oct_Shift+1
 note = 23+(octa*12)
 
-local OutNote  = CheckBox_simple:new(670,430+corrY,98,18, 0.28,0.4,0.7,0.8, "","Arial",16,  OutNote_State,
+local OutNote  = CheckBox_simple:new(670+corrY3,430+corrY,98,18, 0.28,0.4,0.7,0.8, "","Arial",16,  OutNote_State,
                               {
                                    "B" .. Compensate_Oct_Offset+octa .. ": " .. note, 
                                    "C" .. Compensate_Oct_Offset+octa+1 .. ": " .. note+1, 
@@ -4006,7 +4249,7 @@ local OutNote  = CheckBox_simple:new(670,430+corrY,98,18, 0.28,0.4,0.7,0.8, "","
                                    "D" .. Compensate_Oct_Offset+octa+2 .. ": " .. note+15} 
                               )
 
-local OutNote2  = CheckBox_simple:new(670,430+corrY,98,18, 0.28,0.4,0.7,0.8, "","Arial",16,  OutNote_State, -- named notes
+local OutNote2  = CheckBox_simple:new(670+corrY3,430+corrY,98,18, 0.28,0.4,0.7,0.8, "","Arial",16,  OutNote_State, -- named notes
                               {
                                    "B" .. Compensate_Oct_Offset+octa .. ":Kick1", 
                                    "C" .. Compensate_Oct_Offset+octa+1 .. ":Kick2", 
@@ -4028,7 +4271,7 @@ local OutNote2  = CheckBox_simple:new(670,430+corrY,98,18, 0.28,0.4,0.7,0.8, "",
 
 -------------------------
 
-local Velocity = Txt:new(788,384+corrY,55,18, 0.8,0.8,0.8,0.8, "Velocity","Arial",22)
+
 ----------------------------------------
 
 local Slider_TB = {HP_Freq,LP_Freq,Fltr_Gain, 
@@ -4038,9 +4281,9 @@ local Sliders_Grid_TB = {Grid1_Btn, Grid2_Btn, Grid4_Btn, Grid8_Btn, Grid16_Btn,
 
 local Slider_Swing_TB = {Swing_Sld}
 
-local Slider_TB_Trigger = {Gate_VeloScale, VeloMode,OutNote, Velocity}
+local Slider_TB_Trigger = {Gate_VeloScale, VeloMode,OutNote, others_table[10]}
 
-local Slider_TB_Trigger_notes = {Gate_VeloScale, VeloMode,OutNote2, Velocity}
+local Slider_TB_Trigger_notes = {Gate_VeloScale, VeloMode,OutNote2, others_table[10]}
 
 local XFade_TB = {XFade_Sld}
 local XFade_TB_Off = {XFade_Sld_Off}
@@ -4050,10 +4293,6 @@ local SliderRandPan_TB = {RandPan_Sld}
 local SliderRandPtch_TB = {RandPtch_Sld}
 local SliderRand_TBPos = {RandPos_Sld}
 local SliderRand_TBM = {RandRev_Sld}
-
-local Preset = Txt:new(788,384+corrY,55,18, 0.8,0.8,0.8,0.8, "Preset","Arial",22)
-
-local Preset_TB = {Preset} 
 
 -------------------------------------------------------------------------------------
 --- Buttons -------------------------------------------------------------------------
@@ -4102,8 +4341,10 @@ Take_Check = 0
 Trigg_Status = 0
 Reset_Status = 0
 Midi_sampler_offs_stat = 0
+Pitch_Det_offs_stat = 0
 Random_Status = 0
 SliceQ_Status_Rand = 0
+ErrMsg_Status = 0
 
  loopcheck = 0
 ----loopcheck------
@@ -4117,168 +4358,42 @@ end
     r.Undo_BeginBlock() 
 r.PreventUIRefresh(1)
 
--------------------------------Check Razor Edits-----------------------------
-function GetItemsInRange(track, areaStart, areaEnd)
-    local items = {}
-    local itemCount = r.CountTrackMediaItems(track)
-    for k = 0, itemCount - 1 do 
-        local item = r.GetTrackMediaItem(track, k)
-        local pos = r.GetMediaItemInfo_Value(item, "D_POSITION")
-        local length = r.GetMediaItemInfo_Value(item, "D_LENGTH")
-        local itemEndPos = pos+length
-        if (itemEndPos > areaStart and itemEndPos <= areaEnd) or          --check if item is in area bounds
-            (pos >= areaStart and pos < areaEnd) or
-            (pos <= areaStart and itemEndPos >= areaEnd) then
-                table.insert(items,item)
+UnSelectMIDIAndEmptyItems()
+-------------------------------------Check Razor Edits------------------------------------
+function RazorEditSelectionExists()
+    for i=0, r.CountTracks(0)-1 do
+        local retval, x = r.GetSetMediaTrackInfo_String(r.GetTrack(0,i), "P_RAZOREDITS", "string", false)
+        if x ~= "" then return true end
+    end--for
+    return false
+end --RazorEditSelectionExists()
+
+RE_exist = RazorEditSelectionExists()
+
+if RE_exist == true then
+r.PreventUIRefresh(1)
+-------------------Razor edit - Set time selection to razor areas----------------------------------
+left, right = math.huge, -math.huge
+for t = 0, r.CountTracks(0)-1 do
+    local track = r.GetTrack(0, t)
+    local razorOK, razorStr = r.GetSetMediaTrackInfo_String(track, "P_RAZOREDITS", "", false)
+    if razorOK and #razorStr ~= 0 then
+        for razorLeft, razorRight, envGuid in razorStr:gmatch([[([%d%.]+) ([%d%.]+) "([^"]*)"]]) do
+            local razorLeft, razorRight = tonumber(razorLeft), tonumber(razorRight)
+            if razorLeft  < left  then left  = razorLeft end
+            if razorRight > right then right = razorRight end
         end
     end
-    return items
+end
+if left <= right then
+    r.GetSet_LoopTimeRange2(0, true, false, left, right, false)
 end
 
-function SetTrackRazorEdit(track, areaStart, areaEnd, clearSelection)
-    if clearSelection == nil then clearSelection = false end   
-    if clearSelection then
-        local ret, area = r.GetSetMediaTrackInfo_String(track, 'P_RAZOREDITS', '', false)   
-        local str = {}  --parse string, all this string stuff could probably be written better
-        for j in string.gmatch(area, "%S+") do table.insert(str, j) end       
-        local j = 1   --strip existing selections across the track
-        while j <= #str do
-            local GUID = str[j+2]
-            if GUID == '""' then 
-                str[j] = ''
-                str[j+1] = ''
-                str[j+2] = ''
-            end
-            j = j + 3
-        end
-        --insert razor edit 
-        local REstr = tostring(areaStart) .. ' ' .. tostring(areaEnd) .. ' ""'
-        table.insert(str, REstr)
-        local finalStr = ''
-        for i = 1, #str do
-            local space = i == 1 and '' or ' '
-            finalStr = finalStr .. space .. str[i]
-        end
-        local ret, area = r.GetSetMediaTrackInfo_String(track, 'P_RAZOREDITS', finalStr, true)
-        return ret
-    else         
-        local ret, area = r.GetSetMediaTrackInfo_String(track, 'P_RAZOREDITS', '', false)
-        local str = area ~= nil and area .. ' ' or ''
-        str = str .. tostring(areaStart) .. ' ' .. tostring(areaEnd) .. '  ""'       
-        local ret, area = r.GetSetMediaTrackInfo_String(track, 'P_RAZOREDITS', str, true)
-        return ret
-    end
-end
-
-function GetRazorEdits()
-    local trackCount = r.CountTracks(0)
-    local areaMap = {}
-    for i = 0, trackCount - 1 do
-        local track = r.GetTrack(0, i)
-        local ret, area = r.GetSetMediaTrackInfo_String(track, 'P_RAZOREDITS', '', false)
-        if area ~= '' then
-            --PARSE STRING
-            local str = {}
-            for j in string.gmatch(area, "%S+") do
-                table.insert(str, j)
-            end       
-            --FILL AREA DATA
-            local j = 1
-            while j <= #str do
-                local areaStart = tonumber(str[j])        --area data
-                local areaEnd = tonumber(str[j+1]) 
-                local items = {}  --get item data
-                items = GetItemsInRange(track, areaStart, areaEnd)
-                  r.SetTrackSelected(track, true) -- Set Track Selected
-                local areaData = {
-                    areaStart = areaStart,
-                    areaEnd = areaEnd,                
-                    track = track,
-                    items = items,                   
-                }
-                table.insert(areaMap, areaData)
-                j = j + 3
-            end
-        end
-    end
-    return areaMap
-end
-
-function SplitRazorEdits(razorEdits)
-left, right = huge, -huge
-    local areaItems = {}
-    local tracks = {}
-    for i = 1, #razorEdits do
-        local areaData = razorEdits[i]
-        if not areaData.isEnvelope then
-            local items = areaData.items           
-            if tracks[areaData.track] ~= nil then  --recalculate item data for tracks with previous splits
-                items = GetItemsInRange(areaData.track, areaData.areaStart, areaData.areaEnd)
-            end            
-            for j = 1, #items do 
-                local item = items[j]        
-                 if areaData.areaStart  < left  then left  = areaData.areaStart end  --combine areas and set time selection
-                 if areaData.areaEnd > right then right = areaData.areaEnd end
-                 if left <= right then
-                      r.GetSet_LoopTimeRange2(0, true, false, left, right, false)
-                      table.insert(areaItems, item)
-                 end
-            end
-            tracks[areaData.track] = 1
-        end
-    end
-    return areaItems
-end
-
- -- Unselect All Tracks if RE exist --
-    for i = 0, r.CountTracks(0) - 1 do
-        local _, check_area = r.GetSetMediaTrackInfo_String(r.GetTrack(0, i), 'P_RAZOREDITS', '', false)
-        if check_area ~= '' then
-                r.Main_OnCommand(40297, 0) -- Unselect all tracks
-                RE_Status = 1
-        end
-    end
-
- -- Select Items by RE --
-local selections = GetRazorEdits()
-local items = SplitRazorEdits(selections)
-for i = 1, #items do
-    local item = items[i]
-    r.SetMediaItemSelected(item, true)
-end
-
-take_check()
-sel_tr_count = r.CountSelectedTracks(0)
-  if sel_tr_count == 1 then
-        r.Main_OnCommand(42406, 0) -- Clear RE Areas
-     local    start, ending = r.GetSet_LoopTimeRange( 0, 0, 0, 0, 0 )
-           if start ~= ending and Take_Check ~= 1 then
-               r.Main_OnCommand(40061, 0) -- Split at Time Selection
-               r.Main_OnCommand(40635, 0) -- Remove Time Selection
-           end
-    elseif sel_tr_count > 1 then
- goto next_step
-    elseif sel_tr_count ==0 then
-  end
-
-function re_createRE()
-    local itemCount = r.CountSelectedMediaItems(0) -- re-create deleted RE
-    for i = 0, itemCount - 1 do
-        local item = r.GetSelectedMediaItem(0, i)
-        local track = r.GetMediaItem_Track(item)      
-        local itemStartPosition = r.GetMediaItemInfo_Value(item, 'D_POSITION')
-        local itemLength = r.GetMediaItemInfo_Value(item, 'D_LENGTH')
-        local itemEndPosition = itemStartPosition + itemLength
-        SetTrackRazorEdit(track, itemStartPosition, itemEndPosition, false)
-    end
-end
-
-
-function deferinit() -- continuous selection items in RE
-for t = 0, reaper.CountTracks(0)-1 do
-    local track = reaper.GetTrack(0, t)
+---------------------Select media items that overlap razor areas--------------------------------
+for t = 0, r.CountTracks(0)-1 do
+    local track = r.GetTrack(0, t)
     local tR = {}
-    local razorOK, razorStr = reaper.GetSetMediaTrackInfo_String(track, "P_RAZOREDITS", "", false)
+    local razorOK, razorStr = r.GetSetMediaTrackInfo_String(track, "P_RAZOREDITS", "", false)
     if razorOK and #razorStr ~= 0 then
         for razorLeft, razorRight, envGuid in razorStr:gmatch([[([%d%.]+) ([%d%.]+) "([^"]*)"]]) do
             if envGuid == "" then
@@ -4287,154 +4402,118 @@ for t = 0, reaper.CountTracks(0)-1 do
             end
         end
     end
-    for i = 0, reaper.CountTrackMediaItems(track)-1 do
-        local item = reaper.GetTrackMediaItem(track, i)
-        reaper.SetMediaItemSelected(item, false)
-        local left = reaper.GetMediaItemInfo_Value(item, "D_POSITION")
-        local right = left + reaper.GetMediaItemInfo_Value(item, "D_LENGTH")
-        for _, r in ipairs(tR) do
-            if left < r.right and right > r.left then
-                reaper.SetMediaItemSelected(item, true)
+    for i = 0, r.CountTrackMediaItems(track)-1 do
+        local item = r.GetTrackMediaItem(track, i)
+        r.SetMediaItemSelected(item, false)
+        local left = r.GetMediaItemInfo_Value(item, "D_POSITION")
+        local right = left + r.GetMediaItemInfo_Value(item, "D_LENGTH")
+        for _, rr in ipairs(tR) do
+            if left < rr.right and right > rr.left then
+                r.SetMediaItemSelected(item, true)
             end
         end
     end
 end
-reaper.UpdateArrange()
-      if char~=-1 then r.defer(deferinit)  else end     -- defer     r.defer(deferinit)
-end
+--------------------------------------------------------------------------------------------------------------
+            GetLoopTimeRange()
+                  if start ~= ending then
+                        r.Main_OnCommand(40061, 0) -- Split at Time Selection
+                  --   r.Main_OnCommand(40635, 0) -- Remove Time Selection
+                  unselect_if_out_of_time_range()
+                  end
+         
+         sel_tracks_items()
+         UnSelectMIDIAndEmptyItems()
+         sel_tracks_items()
 
+-----------------------------------------Set RE by Selected Items------------------------------------------         
 
-        if RE_Status == 1 then
-             re_createRE()
-             deferinit()
-        end
-::next_step::
+         	r.Main_OnCommand(42406, 0) -- clear area sel
+         	GetLoopTimeRange()
+         	if start ~= ending then
+         		local str_track_razor_edits = string.format([[%s %s '']], start, ending)	
+         		for i = 0, r.CountSelectedTracks(0) - 1 do
+         			local track = r.GetSelectedTrack(0, i)
+         			r.GetSetMediaTrackInfo_String(track, "P_RAZOREDITS", str_track_razor_edits, true) -- set
+         		end
+         	end
+
+         r.PreventUIRefresh(-1)
+         r.UpdateArrange()
+         
+  else -- if not RE
+
+            r.PreventUIRefresh(1)
+            sel_tracks_items()
+
+            GetLoopTimeRange()
+                  if start ~= ending then -- if selection exist
+                        r.Main_OnCommand(40061, 0) -- Split at Time Selection
+                        TimeSelToFirstTrackItems()
+                        UnSelectMIDIAndEmptyItems()
+                  else
+                        TimeSelToFirstTrackItems()
+                        UnSelectMIDIAndEmptyItems()
+                        GetLoopTimeRange() -- check again
+                          if start ~= ending then -- if selection exist
+                             r.Main_OnCommand(40061, 0) -- Split at Time Selection
+                          end
+                  end
+                 unselect_if_out_of_time_range()
+                 r.PreventUIRefresh(-1)
+                 r.UpdateArrange()
+
+end -- if RE_exist
 ---------------------------------------End of RE_Splits----------------------------------------
-
-function sel_tracks_items() --Select only tracks of selected items
-
-  UnselectAllTracks()
-  selected_items_count = r.CountSelectedMediaItems(0)
-
-  for i = 0, selected_items_count - 1  do
-    item = r.GetSelectedMediaItem(0, i) -- Get selected item i
-    track = r.GetMediaItem_Track(item)
-    r.SetTrackSelected(track, true)        
-  end 
-end
-
-function UnselectAllTracks()
-  first_track = r.GetTrack(0, 0)
-          if first_track then
-        r.SetOnlyTrackSelected(first_track)
-        r.SetTrackSelected(first_track, false)
-          end
-end
 
 if ObeyingItemSelection == 1 then
 sel_tracks_items()
 end
 
------------------------------------ObeyingTheSelection------------------------------------
+InitTrackItemName()
 
+-------------------------------------------------------------------------------------------
+r.Main_OnCommand(r.NamedCommandLookup('_SWS_SAVESEL'), 0)  -- Save track selection
+-----------------------------------ObeyingTheSelection------------------------------------
 function collect_param()    -- collect parameters
    selected_tracks_count = r.CountSelectedTracks(0)
    number_of_takes =  r.CountSelectedMediaItems(0)
    if number_of_takes == 0 then return end
    sel_item = r.GetSelectedMediaItem(0, 0)    -- get selected item 
    active_take = r.GetActiveTake(sel_item)  -- active take in item
-   src = r.GetMediaItemTake_Source(active_take)
-   srate =  r.GetMediaSourceSampleRate(src) -- take samplerate (simple wave/MIDI detection)
  end
 
 collect_param()
-local start, ending = r.GetSet_LoopTimeRange( 0, 0, 0, 0, 0 )
+GetLoopTimeRange()
 time_sel_length = ending - start
 if ObeyingTheSelection == 1 and ObeyingItemSelection == 0 and start ~= ending then
     r.Main_OnCommand(40289, 0) -- Item: Unselect all items
-          if time_sel_length >= 0.25 and selected_tracks_count == 1 then
+          if time_sel_length >= 0.25 then
               r.Main_OnCommand(40718, 0) -- Item: Select all items on selected tracks in current time selection
+              UnSelectMIDIAndEmptyItems()
           end
 end
 
 count_itms =  r.CountSelectedMediaItems(0)
 if ObeyingTheSelection == 1 and count_itms ~= 0 and start ~= ending and time_sel_length >= 0.25 then
    take_check()
-   if Take_Check ~= 1 and selected_tracks_count == 1 then
+   if Take_Check ~= 1 then
 
-    --------------------------------------------------------
-    local function no_undo() r.defer(function()end)end;
-    --------------------------------------------------------
-    
-    local startTSel,endTSel = r.GetSet_LoopTimeRange(0,0,0,0,0);
-    if startTSel == endTSel then no_undo() return end;
-    
-    local CountSelItem = r.CountSelectedMediaItems(0);
-    if CountSelItem == 0 then no_undo() return end;
-    
-    local TMSL,UNDO;
-    for t = CountSelItem-1,0,-1 do;
-        local item = r.GetSelectedMediaItem(0,t);
-        local posIt = r.GetMediaItemInfo_Value(item,"D_POSITION");
-        local lenIt = r.GetMediaItemInfo_Value(item, "D_LENGTH");
-        if posIt < endTSel and posIt+lenIt > startTSel then;
-            TMSL = true;
-            if not UNDO then;
-                r.Undo_BeginBlock();
-                r.PreventUIRefresh(1);
-                UNDO = true;
-            end;
-        end;
-        if posIt < endTSel and posIt+lenIt > endTSel then;
-            r.SplitMediaItem(item,endTSel);
-        end;
-        if posIt < startTSel and posIt+lenIt > startTSel then;
-            r.SplitMediaItem(item,startTSel);
-        end;
-    end;
-    
-    if TMSL then;
-        for t = r.CountSelectedMediaItems(0)-1,0,-1 do;
-            local item = r.GetSelectedMediaItem(0,t);
-            local posIt = r.GetMediaItemInfo_Value(item,"D_POSITION");
-            local lenIt = r.GetMediaItemInfo_Value(item, "D_LENGTH");
-            if posIt >= endTSel or posIt+lenIt <= startTSel then;
-                r.SetMediaItemInfo_Value(item,'B_UISEL',0);
-            end;
-        end;
-    end;
-    
-    if UNDO then;
-         r.PreventUIRefresh(-1);
-         r.Undo_EndBlock("Split items by time selection,unselect with items outside of time selection if there is selection inside",-1);
-    else;
-        no_undo();
-    end;    
-    r.UpdateArrange();
+    SplitByTimeAndDeselect()
 
-        collect_param()  
+    collect_param()  
 
-   for i = 0, number_of_takes-1 do -- take fx check
-     local item = r.GetSelectedMediaItem(0, i)
-     local take_count = r.CountTakes(item)
-     for j = 0, take_count-1 do
-       local take = r.GetMediaItemTake(item, j) 
-       if r.TakeFX_GetCount(take) > 0 then 
-        tkfx = 1
-       end
-     end
-   end
-
-       if number_of_takes ~= 1 and srate ~= nil and tkfx ~= 1 and Random_Status ~= 1 then
-           r.Main_OnCommand(40548, 0)  -- Heal Splits -- (если больше одного айтема и не миди айтем, то клей, попытка не деструктивно склеить).
+        if number_of_takes ~= 1 and No_Heal_On_Init == 0 then
+           r.Main_OnCommand(40548, 0)  -- Heal Splits -- (если больше одного айтема и не миди айтем, то попытка не деструктивно склеить).
         end
-       collect_param()    
-       if number_of_takes ~= 1 and srate ~= nil then -- проверяем ещё раз. Если не удалось, клеим деструктивно.
-           r.Main_OnCommand(41588, 0) -- glue (если больше одного айтема и не миди айтем, то клей).
-       tkfx = 0
+  
+       if No_Glue_On_Init == 0 then -- проверяем ещё раз. Если не удалось, клеим деструктивно.
+             GlueMultitrack()
        end
+
    end
 end
+
 -----------------------------------------------------------------------------------------------------
 if ObeyingTheSelection == 1 and time_sel_length < 0.25 and ending ~= start then
 ------------------------------------------Error Message-----------------------------------------
@@ -4442,16 +4521,18 @@ local timer = 2 -- Time in seconds
 local time = reaper.time_precise()
 local function Msg()
    local char = gfx.getchar()
-     if char == 27 or char == -1 or (reaper.time_precise() - time) > timer then ErrMsg_Ststus = 0 return end
-local Get_Sel_ErrMsg = ErrMsg:new(680,450+corrY,260,25, 1, 1, 1, 1, "Time Selection is Too Short (<0.25s)",    "Arial", 22)
+     if char == 27 or char == -1 or (reaper.time_precise() - time) > timer then ErrMsg_Status = 0 return end
+local Get_Sel_ErrMsg = ErrMsg:new(580,35,260,45, 1, 1, 1, 1, "Time Selection is Too Short (<0.25s)")
 local ErrMsg_TB = {Get_Sel_ErrMsg}
-ErrMsg_Ststus = 1
+ErrMsg_Status = 1
      for key,btn    in pairs(ErrMsg_TB)   do btn:draw()    
    gfx.update()
   r.defer(Msg)
 end
 end
-Msg()
+ if ErrMsg_Status ~= 1 then
+ Msg()
+ end
 --------------------------------------End of Error Message-------------------------------------
 Init()
  goto zzz
@@ -4471,93 +4552,79 @@ r.PreventUIRefresh(-1)
 
 --------------------------A Bit More Foolproof----------------------------
 
+
+     number_of_items_m =  r.CountSelectedMediaItems(0)
+  if number_of_items_m < 1 then
+
+-----------------------------------------Error Message1---------------------------------------------------
+
+  local timer = 2 -- Time in seconds
+  local time = reaper.time_precise()
+  local function Msg()
+     local char = gfx.getchar()
+       if char == 27 or char == -1 or (reaper.time_precise() - time) > timer then ErrMsg_Status = 0 return end
+  local Get_Sel_ErrMsg = ErrMsg:new(580,35,260,45, 1, 1, 1, 1, "No items selected")
+  local ErrMsg_TB = {Get_Sel_ErrMsg}
+ErrMsg_Status = 1
+       for key,btn    in pairs(ErrMsg_TB)   do btn:draw()    
+     gfx.update()
+    r.defer(Msg)
+  end
+  end
+if ErrMsg_Status ~= 1 then
+Msg()
+end
+
+--------------------------------------End of Error Message1-------------------------------------------
+Init()
+
+  return
+
+  end -- не запускать, если нет айтемов.
+
+
 sel_tracks_items() 
 
-function collect_itemtake_param()    -- collect parameter on sel item and active take for SM tables and displacement calcs...
-   selected_tracks_count = r.CountSelectedTracks(0)
-   number_of_takes =  r.CountSelectedMediaItems(0)
-   if number_of_takes == 0 then return end
-   sel_item = r.GetSelectedMediaItem(0, 0)    -- get selected item
-   active_take = r.GetActiveTake(sel_item)  -- active take in item
-   mute_check = r.GetMediaItemInfo_Value(sel_item, "B_MUTE")
- end
- 
-   collect_itemtake_param()              -- get bunch of parameters about this item
+collect_itemtake_param()              -- get bunch of parameters about this item
 
 take_check()
 
-if selected_tracks_count > 1 then
+if  Take_Check == 1 and number_of_takes == 1 then  
 
-------------------------------------------Error Message-----------------------------------------
-
-local timer = 2 -- Time in seconds
-local time = reaper.time_precise()
-local function Msg()
-   local char = gfx.getchar()
-     if char == 27 or char == -1 or (reaper.time_precise() - time) > timer then ErrMsg_Ststus = 0 return end
-local Get_Sel_ErrMsg = ErrMsg:new(680,450+corrY,260,25, 1, 1, 1, 1, "Only single track items, please",    "Arial", 22)
-local ErrMsg_TB = {Get_Sel_ErrMsg}
-ErrMsg_Ststus = 1
-     for key,btn    in pairs(ErrMsg_TB)   do btn:draw()    
-   gfx.update()
-  r.defer(Msg)
-end
-end
-Msg()
-
---------------------------------------End of Error Message--------------------------------------------
-
-Init()
-
- goto zzz 
-end -- не запускать, если айтемы находятся на разных треках.
-
-if  Take_Check == 1 then  
-
-------------------------------------Error Message----------------------------------------------
+------------------------------------Error Message3----------------------------------------------
 
 local timer = 2 -- Time in seconds
 local time = reaper.time_precise()
 local function Msg()
    local char = gfx.getchar()
-     if char == 27 or char == -1 or (reaper.time_precise() - time) > timer then ErrMsg_Ststus = 0 return end
-local Get_Sel_ErrMsg = ErrMsg:new(680,450+corrY,260,25, 1, 1, 1, 1, "Only Wave items, please",    "Arial", 22)
+     if char == 27 or char == -1 or (reaper.time_precise() - time) > timer then ErrMsg_Status = 0 return end
+local Get_Sel_ErrMsg = ErrMsg:new(580,35,260,45, 1, 1, 1, 1, "Only Wave items, please")
 local ErrMsg_TB = {Get_Sel_ErrMsg}
-ErrMsg_Ststus = 1
+ErrMsg_Status = 1
      for key,btn    in pairs(ErrMsg_TB)   do btn:draw()    
    gfx.update()
   r.defer(Msg)
 end
 end
+if ErrMsg_Status ~= 1 then
 Msg()
-
--------------------------------------End of Error Message----------------------------------------
+end
+-------------------------------------End of Error Message3----------------------------------------
 
 Init()
 
  goto zzz 
 end -- не запускать, если MIDI айтем.
 
-   for i = 0, number_of_takes-1 do -- take fx check
-     local item = r.GetSelectedMediaItem(0, i)
-     local take_count = r.CountTakes(item)
-     for j = 0, take_count-1 do
-       local take = r.GetMediaItemTake(item, j) 
-       if r.TakeFX_GetCount(take) > 0 then 
-        tkfx = 1
-       end
-     end
-   end
 
- if number_of_takes ~= 1 and Take_Check == 0 and tkfx ~= 1 and Random_Status ~= 1 then
+ if number_of_takes ~= 1 and Take_Check == 0 and Random_Status ~= 1 and No_Heal_On_Init == 0 then
      r.Main_OnCommand(40548, 0)  -- Heal Splits -- (если больше одного айтема и не миди айтем, то клей, попытка не деструктивно склеить).
  end
 
-   collect_itemtake_param()
+  if No_Glue_On_Init == 0 then 
 
-  if selected_tracks_count == 1 and number_of_takes > 1 and Take_Check == 0 then 
-     r.Main_OnCommand(41588, 0) -- glue (если больше одного айтема, то клей).
-     tkfx = 0
+             GlueMultitrack()
+
   end
 
 --------------------------------------------------------------------------------
@@ -4586,6 +4653,10 @@ if Wave.State then
       DrawGridGuides()
 end
 
+if Midi_Sampler.norm_val == 3 and RebuildPeaksOnStart == 1 then
+    r.Main_OnCommand(40441,0) --rebuild peaks when the script starts
+end
+
 ::zzz::
 
 end
@@ -4602,14 +4673,91 @@ end
 local Just_Slice = Button:new(400,380+corrY,67,25, 0.3,0.3,0.3,1, "Slice",    "Arial",16 )
 Just_Slice.onClick = 
 function()
-   if Wave.State then Wave:Just_Slice() end 
+   if Wave.State then 
+ErrMsg_Status = 0
+
+sel_tracks_items()
+
+collect_param()
+
+if selected_tracks_count > 1 and number_of_takes > 1 then -- multitrack
+
+     time_start = reaper.time_precise()       
+        local function Main()     
+            local elapsed = reaper.time_precise() - time_start       
+            if elapsed >= 0.02 then
+                 ErrMsg_Status = 0
+            ----------------------------------------------------------------
+                 Wave:Just_Slice() 
+             ------------------------------------------------------------------
+
+              runcheck = 0
+                return
+            else
+             ErrMsg_Status = 1
+
+               Wave:show_process_wait()
+
+              runcheck = 1
+                reaper.defer(Main)
+            end           
+        end
+        
+        if runcheck ~= 1 then
+           Main()
+        end
+
+else -- if single track
+  Wave:Just_Slice() 
+end
+
+end 
 end 
 
 -- Create Quantize Slices Button ----------------------------
 local Quantize_Slices = Button:new(469,380+corrY,25,25, 0.3,0.3,0.3,1, "Q",    "Arial",16 )
 Quantize_Slices.onClick = 
 function()
-   if Wave.State then Wave:Quantize_Slices() end 
+   if Wave.State then 
+
+ErrMsg_Status = 0
+
+sel_tracks_items()
+
+collect_param()
+
+if selected_tracks_count > 1 and number_of_takes > 1 then -- multitrack
+
+     time_start = reaper.time_precise()       
+        local function Main()     
+            local elapsed = reaper.time_precise() - time_start       
+            if elapsed >= 0.02 then
+                 ErrMsg_Status = 0
+            ----------------------------------------------------------------
+                 Wave:Quantize_Slices()
+             ------------------------------------------------------------------
+
+              runcheck = 0
+                return
+            else
+             ErrMsg_Status = 1
+
+               Wave:show_process_wait()
+
+              runcheck = 1
+                reaper.defer(Main)
+            end           
+        end
+        
+        if runcheck ~= 1 then
+           Main()
+        end
+
+else -- if single track
+Wave:Quantize_Slices()
+end
+ 
+end 
 end 
 
 -- Create Add Markers Button ----------------------------
@@ -4635,7 +4783,7 @@ function Randomizer()
         r.Main_OnCommand(41638, 0)  -- Random Order  
     end
 
-math.randomseed(r.time_precise()*os.time()/1e3)
+math.randomseed(reaper.time_precise()*os.time()/1e3)
 local t = {}
 local sel_items = {}
 local function SaveSelItems()
@@ -4673,7 +4821,7 @@ function random_numbers_less_than(x)
      t[e] = i 
   end
   shuffle(t)
-  local max = floor(x/((RandRevVal/10)+1))
+  local max = x//((RandRevVal/10)+1)
   for i = 1, max do 
     d = d + 1
     t_res[d] = t[i] 
@@ -4746,7 +4894,6 @@ for i = 1, items - 1 do --RANDOMIZE Position instead first item
                       local random_position = random(ceil((RandPosval/10)+1))-1
                       local random_polarity2 = random()*2 - 1
                       local it_start = r.GetMediaItemInfo_Value(item, "D_POSITION")
-                      local tempo_corr = 1/(r.Master_GetTempo()/120)
                       local random_pos = it_start+((random_position/300)*random_polarity2)*tempo_corr
                       r.SetMediaItemInfo_Value(item, "D_POSITION", random_pos)
                  end
@@ -4873,7 +5020,7 @@ function()
 end
 
 -- Random_Clear Button ----------------------------
-local Random_SetupClearB = Button_small:new(772,467+corrY2,40,14, 0.3,0.3,0.3,1, "Clear",    "Arial",16 )
+local Random_SetupClearB = Button_small:new(772,470,40,14, 0.3,0.3,0.3,1, "Clear",    "Arial",16 )
 Random_SetupClearB.onClick = 
 function()
 Random_Order = 1 
@@ -4894,7 +5041,7 @@ r.SetExtState('cool_MK Slicer.lua','Random_Reverse',Random_Reverse,true);
 end
 
 -- Random_Order Button ----------------------------
-local Random_OrderB = Button_small:new(675,377+corrY2,60,14, 0.3,0.3,0.3,1, "Order",    "Arial",5 )
+local Random_OrderB = Button_small:new(675,380,60,14, 0.3,0.3,0.3,1, "Order",    "Arial",5 )
 Random_OrderB.onClick = 
 function()
      if Random_Order ~= 1 then
@@ -4906,7 +5053,7 @@ function()
 end
 
 -- Random_Vol Button ----------------------------
-local Random_VolB = Button_small:new(675,392+corrY2,60,14, 0.3,0.3,0.3,1, "Volume",    "Arial",5 )
+local Random_VolB = Button_small:new(675,395,60,14, 0.3,0.3,0.3,1, "Volume",    "Arial",5 )
 Random_VolB.onClick = 
 function()
      if Random_Vol ~= 1 then
@@ -4918,7 +5065,7 @@ function()
 end
 
 -- Random_Pan Button ----------------------------
-local Random_PanB = Button_small:new(675,407+corrY2,60,14, 0.3,0.3,0.3,1, "Pan",    "Arial",5 )
+local Random_PanB = Button_small:new(675,410,60,14, 0.3,0.3,0.3,1, "Pan",    "Arial",5 )
 Random_PanB.onClick = 
 function()
      if Random_Pan ~= 1 then
@@ -4930,7 +5077,7 @@ function()
 end
 
 -- Random_Pitch Button ----------------------------
-local Random_PitchB = Button_small:new(675,422+corrY2,60,14, 0.3,0.3,0.3,1, "Pitch",    "Arial",5 )
+local Random_PitchB = Button_small:new(675,425,60,14, 0.3,0.3,0.3,1, "Pitch",    "Arial",5 )
 Random_PitchB.onClick = 
 function()
      if Random_Pitch ~= 1 then
@@ -4942,7 +5089,7 @@ function()
 end
 
 -- Random_Position Button ----------------------------
-local Random_PositionB = Button_small:new(675,437+corrY2,60,14, 0.3,0.3,0.3,1, "Position",    "Arial",5 )
+local Random_PositionB = Button_small:new(675,440,60,14, 0.3,0.3,0.3,1, "Position",    "Arial",5 )
 Random_PositionB.onClick = 
 function()
      if Random_Position ~= 1 then
@@ -4954,7 +5101,7 @@ function()
 end
 
 -- Random_Reverse Button ----------------------------
-local Random_ReverseB = Button_small:new(675,452+corrY2,60,14, 0.3,0.3,0.3,1, "Reverse",    "Arial",5 )
+local Random_ReverseB = Button_small:new(675,455,60,14, 0.3,0.3,0.3,1, "Reverse",    "Arial",5 )
 Random_ReverseB.onClick = 
 function()
      if Random_Reverse ~= 1 then
@@ -4966,7 +5113,7 @@ function()
 end
 
 -- Random_Mute Button ----------------------------
-local Random_MuteB = Button_small:new(675,467+corrY2,60,14, 0.3,0.3,0.3,1, "Mute",    "Arial",5 )
+local Random_MuteB = Button_small:new(675,470,60,14, 0.3,0.3,0.3,1, "Mute",    "Arial",5 )
 Random_MuteB.onClick = 
 function()
      if Random_Mute ~= 1 then
@@ -4990,16 +5137,18 @@ if Wave.State then
          local time = reaper.time_precise()
          local function Msg()
             local char = gfx.getchar()
-              if char == 27 or char == -1 or (reaper.time_precise() - time) > timer then ErrMsg_Ststus = 0 return end
-         local Get_Sel_ErrMsg = ErrMsg:new(680,450+corrY,260,25, 1, 1, 1, 1, "Select at least one option in Rnd.Set",    "Arial", 22)
+              if char == 27 or char == -1 or (reaper.time_precise() - time) > timer then ErrMsg_Status = 0 return end
+         local Get_Sel_ErrMsg = ErrMsg:new(580,35,260,45, 1, 1, 1, 1, "Select at least one option in Rnd.Set")
          local ErrMsg_TB = {Get_Sel_ErrMsg}
-         ErrMsg_Ststus = 1
+         ErrMsg_Status = 1
               for key,btn    in pairs(ErrMsg_TB)   do btn:draw()    
             gfx.update()
            r.defer(Msg)
          end
          end
+         if ErrMsg_Status ~= 1 then
          Msg()
+         end
          --------------------------------------End of Error Message------------------------------------  
          Init()
 
@@ -5028,40 +5177,6 @@ if XFadeOff == 0 then
 
 --  r.Main_OnCommand(r.NamedCommandLookup("_SWS_AWFILLGAPSQUICK"),0) -- fill gaps 
 
-        CrossfadeT = x_fade
-
-    local function Overlap(CrossfadeT);
-        local t,ret = {};
-        local items_count = r.CountSelectedMediaItems(0);
-        if items_count == 0 then return 0 end;
-        for i = 1 ,items_count do;
-            local item = r.GetSelectedMediaItem(0,i-1);
-            local trackIt = r.GetMediaItem_Track(item);
-            if t[tostring(trackIt)] then;
-                ----
-                ret = 1;
-                local crossfade_time = (CrossfadeT or 0)/1000;
-                local take = r.GetActiveTake(item); 
-                local pos = r.GetMediaItemInfo_Value(item,'D_POSITION');
-                local length = r.GetMediaItemInfo_Value( item,'D_LENGTH');
-                local SnOffs = r.GetMediaItemInfo_Value( item,'D_SNAPOFFSET');
-                local rateIt = r.GetMediaItemTakeInfo_Value(take,'D_PLAYRATE');
-                local ofSetIt = r.GetMediaItemTakeInfo_Value(take,'D_STARTOFFS');
-
-                if pos < crossfade_time then crossfade_time = pos end;
-                ----
-                r.SetMediaItemInfo_Value(item,'D_POSITION',pos-crossfade_time);
-                r.SetMediaItemInfo_Value(item,'D_LENGTH',length+crossfade_time);
-                r.SetMediaItemTakeInfo_Value(take,'D_STARTOFFS',ofSetIt-(crossfade_time*rateIt));
-                r.SetMediaItemInfo_Value(item,'D_SNAPOFFSET',SnOffs+crossfade_time);
-            else;
-                t[tostring(trackIt)] = trackIt;
-            end;
-        end;
-        if ret == 1 then r.Main_OnCommand(41059,0) end;
-        return ret or 0;
-    end;
-    
     r.Undo_BeginBlock();
     local Over = Overlap(CrossfadeT);
     r.Undo_EndBlock("Overlap",Over-Over*2);
@@ -5086,7 +5201,7 @@ function()
 end
 
 -- Create Midi Button ----------------------------
-local Create_MIDI = Button:new(670,380+corrY,98,25, 0.3,0.3,0.3,1, "MIDI",    "Arial",16 )
+local Create_MIDI = Button:new(670+corrY3,380+corrY,98,25, 0.3,0.3,0.3,1, "MIDI",    "Arial",16 )
 Create_MIDI.onClick = 
 
 function()
@@ -5096,10 +5211,18 @@ if Wave.State and MIDISmplr_Status == 0 and Trigg_Status == 0 then
   M_Check = 0
   MIDISampler = 1
 
-sel_tracks_items() 
-selected_tracks_count = r.CountSelectedTracks(0)
+number_of_items_m =  r.CountSelectedMediaItems(0)
+if Wave.State and number_of_items_m < 1 then
+     local lastitem = r.GetExtState('_Slicer_', 'ItemToSlice')
+     local item =  r.BR_GetMediaItemByGUID( 0, lastitem )
+     r.SetMediaItemSelected(item, true)
+end
 
-  if selected_tracks_count > 1 then
+
+
+--[[
+     number_of_items_m =  r.CountSelectedMediaItems(0)
+  if number_of_items_m < 1 then
 
 -----------------------------------------Error Message1---------------------------------------------------
 
@@ -5107,18 +5230,52 @@ selected_tracks_count = r.CountSelectedTracks(0)
   local time = reaper.time_precise()
   local function Msg()
      local char = gfx.getchar()
-       if char == 27 or char == -1 or (reaper.time_precise() - time) > timer then ErrMsg_Ststus = 0 return end
-  local Get_Sel_ErrMsg = ErrMsg:new(680,450+corrY,260,25, 1, 1, 1, 1, "Only single track items, please",    "Arial", 22)
+       if char == 27 or char == -1 or (reaper.time_precise() - time) > timer then ErrMsg_Status = 0 return end
+  local Get_Sel_ErrMsg = ErrMsg:new(580,35,260,45, 1, 1, 1, 1, "No items selected")
   local ErrMsg_TB = {Get_Sel_ErrMsg}
-ErrMsg_Ststus = 1
+ErrMsg_Status = 1
        for key,btn    in pairs(ErrMsg_TB)   do btn:draw()    
      gfx.update()
     r.defer(Msg)
   end
   end
-  Msg()
+if ErrMsg_Status ~= 1 then
+Msg()
+end
 
 --------------------------------------End of Error Message1-------------------------------------------
+Init()
+
+  return
+
+  end -- не запускать, если нет айтемов.
+]]--
+
+--sel_tracks_items() 
+selected_tracks_count = r.CountSelectedTracks(0)
+
+  if selected_tracks_count > 1 then
+
+-----------------------------------------Error Message2---------------------------------------------------
+
+  local timer = 2 -- Time in seconds
+  local time = reaper.time_precise()
+  local function Msg()
+     local char = gfx.getchar()
+       if char == 27 or char == -1 or (reaper.time_precise() - time) > timer then ErrMsg_Status = 0 return end
+  local Get_Sel_ErrMsg = ErrMsg:new(580,35,260,45, 1, 1, 1, 1, "Only single track items, please")
+  local ErrMsg_TB = {Get_Sel_ErrMsg}
+ErrMsg_Status = 1
+       for key,btn    in pairs(ErrMsg_TB)   do btn:draw()    
+     gfx.update()
+    r.defer(Msg)
+  end
+  end
+if ErrMsg_Status ~= 1 then
+Msg()
+end
+
+--------------------------------------End of Error Message2-------------------------------------------
 Init()
 
   M_Check = 1
@@ -5131,24 +5288,26 @@ take_check()
 
 if  Take_Check == 1 then  
 
-------------------------------------Error Message2----------------------------------------------
+------------------------------------Error Message3----------------------------------------------
 
 local timer = 2 -- Time in seconds
 local time = reaper.time_precise()
 local function Msg()
    local char = gfx.getchar()
-     if char == 27 or char == -1 or (reaper.time_precise() - time) > timer then ErrMsg_Ststus = 0 return end
-local Get_Sel_ErrMsg = ErrMsg:new(680,450+corrY,260,25, 1, 1, 1, 1, "Only Wave items, please",    "Arial", 22)
+     if char == 27 or char == -1 or (reaper.time_precise() - time) > timer then ErrMsg_Status = 0 return end
+local Get_Sel_ErrMsg = ErrMsg:new(580,35,260,45, 1, 1, 1, 1, "Only Wave items, please")
 local ErrMsg_TB = {Get_Sel_ErrMsg}
-ErrMsg_Ststus = 1
+ErrMsg_Status = 1
      for key,btn    in pairs(ErrMsg_TB)   do btn:draw()    
    gfx.update()
   r.defer(Msg)
 end
 end
+if ErrMsg_Status ~= 1 then
 Msg()
+end
 
--------------------------------------End of Error Message2----------------------------------------
+-------------------------------------End of Error Message3----------------------------------------
 
 Take_Check = 0
 
@@ -5164,7 +5323,7 @@ end -- не запускать, если MIDI айтем.
 
    r.Main_OnCommand(41844, 0)  ---Delete All Markers  
 
-  sel_tracks_items() 
+--  sel_tracks_items() 
 
 function pitch_and_rate_check()
      selected_tracks_count = r.CountSelectedTracks(0)
@@ -5207,7 +5366,7 @@ end;
 
 pitch_and_rate_check()
 
-   if take_pitch ~= 0 or take_playrate ~= 1.0 or number_of_takes ~= 1 then
+   if take_pitch ~= 0 or (take_playrate ~= 1.0 and Midi_Sampler.norm_val == 1) or number_of_takes ~= 1 then
          Glue_protection()
          tkfx = 0
   end
@@ -5215,20 +5374,28 @@ pitch_and_rate_check()
 
   if (Midi_Sampler.norm_val == 1) then  
 
-  Midi_sampler_offs_stat = 1
-  Wave:Create_Track_Accessor() 
-  Wave:Just_Slice()   
-  Wave:Load_To_Sampler() 
+      Midi_sampler_offs_stat = 1
+      Wave:Create_Track_Accessor() 
+      Wave:Just_Slice()   
+      Wave:Load_To_Sampler() 
+    
+      Wave.State = false -- reset Wave.State
+    
+       r.Undo_EndBlock("Create MIDI", -1) 
+     
+          elseif Midi_Sampler.norm_val == 2 then
+                 cursorpos = r.GetCursorPosition()
+                       MIDITrigger()
+        
+          elseif (Midi_Sampler.norm_val == 3) then  
+                 cursorpos = r.GetCursorPosition()
+                       Pitch_Det_offs_stat = 1
+                  --     Wave:Create_Track_Accessor() 
+                       Wave:Just_Slice() 
+                       MIDITrigger_pitched()
 
-  Wave.State = false -- reset Wave.State
-
-      r.Undo_EndBlock("Create MIDI", -1) 
-
-  else
-              MIDITrigger()
-
-  end
-
+                       r.Undo_EndBlock("Audio to MIDI", -1) 
+          end  
   end 
   end
 end
@@ -5242,6 +5409,8 @@ local Checkbox_TB_preset = {Sampler_preset}
 
 local Button_TB = {Get_Sel_Button, Settings, Just_Slice, Quantize_Slices, Add_Markers, Quantize_Markers, Random, Reset_All, Random_SetupB}
 local Button_TB2 = {Create_MIDI, Midi_Sampler}
+local Pitch_Det_Options_TB = {Pitch_Det_Options, Pitch_Det_Options2, Pitch_Preset}
+local  Create_Replace_TB = {others_table[11], others_table[12], others_table[13], Create_Replace}
 local Random_Setup_TB2 = {elm_table[6], elm_table[7], Random_OrderB, Random_VolB, Random_PitchB, Random_PanB, Random_MuteB, Random_PositionB, Random_ReverseB, Random_SetupClearB}
  
 -------------------------------------------------------------------------------------
@@ -5262,8 +5431,8 @@ end
 --------------------------------------------------
 -- View Checkboxes -------------------------------
 -------------------------
-local ViewMode = CheckBox_Show:new(970,380+corrY,55,18,  0.28,0.4,0.7,0.8, "Show: ","Arial",16,  1,
-                              { "All", "Original", "Filtered" } )
+local ViewMode = CheckBox_Show:new(970,380+corrY,55,18,  0.28,0.4,0.7,0.8, "","Arial",16,  1,
+                              { "View All", "Original", "Filtered" } )
 ViewMode.onClick = 
 function() 
    if Wave.State then Wave:Redraw() end 
@@ -5324,7 +5493,8 @@ function Gate_Gl:Apply_toFiltered()
        -- Gate main for ------------------------------------------------
        -----------------------------------------------------------------
        for i = 1, Wave.selSamples, 1 do
-           local input = abs(Wave.out_buf[i]) -- abs sample value(abs envelope)
+           local input = Wave.out_buf[i] -- abs sample value(abs envelope)
+           if input < 0 then input = input*-1 end
            --------------------------------------------
            -- Envelope1(fast) -------------------------
            if envOut1 < input then envOut1 = input + ga1 * (envOut1 - input) 
@@ -5424,119 +5594,58 @@ function Gate_Gl:Reduce_Points() -- Надо допилить!!!
     for i=1, #self.State_Points, 2 do
        -- В результирующую таблицу копируются значения, входящие в диапазон --
        if self.State_Points[i+1][mode]>= reduce_val then
-         local p = #self.Res_Points+1
-         self.Res_Points[p]   = self.State_Points[i]+(Offset_Sld.form_val/1000*srate)
-         self.Res_Points[p+1] = {self.State_Points[i+1][1], self.State_Points[i+1][2]}
-       
+            local p = #self.Res_Points+1
+            self.Res_Points[p]   = self.State_Points[i]+(Offset_Sld.form_val/1000*srate)
+            self.Res_Points[p+1] = {self.State_Points[i+1][1], self.State_Points[i+1][2]}
         end
     end 
  end     
 -------------------------------------------------------------------------------
 ------------------------------View "Grid by" Lines------------------------------
 -------------------------------------------------------------------------------
+
 function DrawGridGuides()
- 
+--local start_time = reaper.time_precise()
 local lastitem = r.GetExtState('_Slicer_', 'ItemToSlice')
      
      local item =  r.BR_GetMediaItemByGUID( 0, lastitem )
-                if item then 
--------------------------------SAVE GRID-----------------------------
---local _, division, swingmode, swingamt = r.GetSetProjectGrid(0, 0)
 
---local ext_sec, ext_key = 'savegrid', 'grid'
---r.SetExtState(ext_sec, ext_key, division..','..swingmode..','..swingamt, 0)
----------------------------SET NEWGRID-------------------------------------
-if  Guides.norm_val == 2 then  
---[[
-     if Guides == 0 then r.Main_OnCommand(40781, 0) --1
-          elseif Guides == 1 then r.Main_OnCommand(42007, 0)
-          elseif Guides == 2 then r.Main_OnCommand(40780, 0) --2
-          elseif Guides == 3 then r.Main_OnCommand(42000, 0)
-          elseif Guides == 4 then r.Main_OnCommand(40779, 0) -- 4
-          elseif Guides == 5 then r.Main_OnCommand(41214, 0)  
-          elseif Guides == 6 then r.Main_OnCommand(40778, 0) --8 
-          elseif Guides == 7 then r.Main_OnCommand(40777, 0)
-          elseif Guides == 8 then r.Main_OnCommand(40776, 0) --16
-          elseif Guides == 9 then r.Main_OnCommand(41213, 0)
-          elseif Guides == 10 then r.Main_OnCommand(40775, 0)-- 32
-          elseif Guides == 11 then r.Main_OnCommand(41212, 0)
-          elseif Guides == 12 then r.Main_OnCommand(40774, 0) -- 64
-     end
-]]--
-end
- Grid_Points_r ={}
- Grid_Points = {}
-local p = 0
+                if item then 
+
+Grid_Points ={}
+Grid_Points_S ={}
+
 local b = 0
+
+if loop_start == nil then loop_start = 0 end
+if loop_end == nil then loop_end = 0 end
+if srate == nil then return end
+
 local blueline = loop_start 
    while (blueline <= loop_end) do
 
-function beatc(beatpos)
-   local retval, measures, cml, fullbeats, cdenom = r.TimeMap2_timeToBeats(0, beatpos)
-   local _, division, _, _ = r.GetSetProjectGrid(0,false)
-   beatpos = r.TimeMap2_beatsToTime(0, fullbeats +(division*4))
-   return beatpos
-end
-blueline = beatc(blueline)
-    
-    p = p + 1
-    Grid_Points[p] = floor(blueline*srate)+(Offset_Sld.form_val/1000*srate)
-    
+        blueline = beatc(blueline)
+
         b = b + 1
-        Grid_Points_r[b] = floor((blueline - loop_start)*srate)+(Offset_Sld.form_val/1000*srate)
+        Grid_Points[b] = (((blueline - loop_start)*srate)//1)+(Offset_Sld.form_val/1000*srate)
+        Grid_Points_S[b] = ((blueline*srate)//1)+(Offset_Sld.form_val/1000*srate)
+
    end 
  end 
-------------------------------------RESTORE GRID----------------------------
--- local ext_sec, ext_key = 'savegrid', 'grid'
- --local str = r.GetExtState(ext_sec, ext_key)
- --if not str or str == '' then return end
- 
- --local division, swingmode, swingamt = str:match'(.*),(.*),(.*)'
- --if not (division and swingmode and swingamt) then return end
- 
- --r.GetSetProjectGrid(0, 1, division, swingmode, swingamt)
-end
 
--------------------------------------------------------------------------------
-------------------------View Main (Project) Grid--------------------------------
--------------------------------------------------------------------------------
-function DrawGridGuides2() 
-local lastitem = r.GetExtState('_Slicer_', 'ItemToSlice')    
-    local  item =  r.BR_GetMediaItemByGUID( 0, lastitem )
-                if item then                               
--------------------------------SAVE GRID-----------------------------
- local _, division, swingmode, swingamt = r.GetSetProjectGrid(0, 0)
----------------------------SET NEWGRID-------------------------------
-Grid_Points_Ruler ={}
-local d = 0
-local grinline2 = loop_start 
-   while (grinline2 <= loop_end) do
-
-function beatc(beatpos)
-   local retval, measures, cml, fullbeats, cdenom = r.TimeMap2_timeToBeats(0, beatpos)
-   local _, division, _, _ = r.GetSetProjectGrid(0,false)
-   beatpos = r.TimeMap2_beatsToTime(0, fullbeats +(division*4))
-   return beatpos
-end
-grinline2 = beatc(grinline2)
-
-        d = d + 1
-        Grid_Points_Ruler[d] = floor((grinline2 - loop_start)*srate)
-   end 
- end 
---------------------------------RESTORE GRID-------------------------
- r.GetSetProjectGrid(0, 1, division, swingmode, swingamt)
+--reaper.ShowConsoleMsg("Full Process time = " .. reaper.time_precise()-start_time .. '\n') -- time test 
 end
 
 -----------------------------------------------------------------------
 ---  Gate - Draw Gate Lines  -------------------------------------------
 -----------------------------------------------------------------------
 function Gate_Gl:draw_Lines()
-  --if not self.Res_Points or #self.Res_Points==0 then return end -- return if no lines
   if not self.Res_Points then return end -- return if no lines
     --------------------------------------------------------
     -- Set values ------------------------------------------
     --------------------------------------------------------
+    local sw_shift = 0
+    local velo_y, line_x_mouse_x, line_x
     local mode = VeloMode.norm_val
     local offset = Wave.h * Gate_VeloScale.norm_val
     self.scale = Gate_VeloScale.norm_val2 - Gate_VeloScale.norm_val
@@ -5548,84 +5657,81 @@ function Gate_Gl:draw_Lines()
     --------------------------------------------------------
  
  if (Guides.norm_val == 1) then 
-   
+
     -- Draw, capture trig lines ----------------------------
     --------------------------------------------------------
     gfx.set(0.9, 0.9, 0, 0.7) -- gate line, point color -- цвет маркеров транзиентов
     ----------------------------
    
     for i=1, #self.Res_Points, 2 do
-        local line_x = Wave.x + (self.Res_Points[i] - self.start_smpl) * self.Xsc  -- line x coord
-        local velo_y = self.Yop -  self.Res_Points[i+1][mode] * self.Ysc           -- velo y coord    
-   
-    ------------------------
+           line_x = Wave.x + (self.Res_Points[i] - self.start_smpl) * self.Xsc  -- line x coord
+
+           if (Midi_Sampler.norm_val == 2) then
+                 velo_y = self.Yop -  self.Res_Points[i+1][mode] * self.Ysc  -- velo y coord    
+           end
+        ------------------------
         -- draw line, velo -----
         ------------------------
         if line_x>=Wave.x and line_x<=Wave.x+Wave.w then -- Verify line range
            gfx.line(line_x, Wave.y, line_x, Wave.y+Wave.h-1)  -- Draw Trig Line
            
            if (Midi_Sampler.norm_val == 2) then
-           gfx.circle(line_x, velo_y, 3,1,1)             -- Draw Velocity point
-        end
+              gfx.circle(line_x, velo_y, 3,1,1)             -- Draw Velocity point
+           end
         end
         
             ------------------------
             -- Get mouse -----------
             ------------------------
-            if not self.cap_ln and abs(line_x-gfx.mouse_x)< (10*Z_w) then -- здесь 10*Z_w - величина окна захвата маркера.
-               if Wave:mouseDown() or Wave:mouseR_Down() then self.cap_ln = i end
+            line_x_mouse_x = line_x-gfx.mouse_x
+            if line_x_mouse_x < 0 then line_x_mouse_x = line_x_mouse_x*-1 end
+            if not self.cap_ln and line_x_mouse_x < (10*Z_w) then -- здесь 10*Z_w - величина окна захвата маркера.
+                if Wave:mouseDown() or Wave:mouseR_Down() then self.cap_ln = i end
             end
-        end
-------------------------------------------------------------------------------------------------------------
+    end
 
- else       
+       --------------------------------------------------------
+       -- Operations with captured lines(if exist) ------------
+       --------------------------------------------------------
+       Gate_Gl:manual_Correction()
+       -- Update captured state if mouse released -------------
+       if self.cap_ln and Wave:mouseUp() then self.cap_ln = false  
+       end     
+
+ else  ------------------------------------------------------------------------------------------------------------     
 
 gfx.set(0, 0.7, 0.7, 0.7) -- gate line, point color -- цвет маркеров при отображении сетки
 
-local Grid_Points_r = Grid_Points_r or {};     
+local Grid_Points = Grid_Points or {};     
 local _, division, swingmode, swingamt = r.GetSetProjectGrid(0, 0)
-local tempo_corr = 1/(r.Master_GetTempo()/120)
+if division < 0.0078125 then division = 0.0078125 end
 local lnt_corr = (loop_length/tempo_corr)/8
-   for i=1, #Grid_Points_r  do
+if 0.00007 > self.Xsc*division then self.Xsc = 0.00007/division end
 
+   for i=1, #Grid_Points  do
+
+   if Swing_on == 1 and swing_slider_amont ~= 0 then
          sw_shift = swingamt*(1-abs(division-1))
          if IsEven(i) == false and swingmode == 1 then 
-         sw_shift = (sw_shift*128*Wave.Zoom*Z_w)/lnt_corr
-         else
-         sw_shift = 0
+            sw_shift = (sw_shift*128*Wave.Zoom*Z_w)/lnt_corr
+              else
+            sw_shift = 0
          end
+    end
+         OffsSldCorrG = 0.5/1000*srate
+         line_x  = Wave.x+sw_shift + (Grid_Points[i] - self.start_smpl+OffsSldCorrG) * self.Xsc  -- line x coord
 
-         local line_x  = Wave.x+sw_shift + (Grid_Points_r[i] - self.start_smpl) * self.Xsc  -- line x coord
-
-         --------------------
-         -- draw line 8 -----
-         ----------------------
-       
          if line_x>=Wave.x and line_x<=Wave.x+Wave.w then -- Verify line range
             gfx.line(line_x, Wave.y, line_x, Wave.y+Wave.h-1)  -- Draw Trig Line
          end
 
-          ------------------------
-          -- Get mouse -----------
-          ------------------------
-          if not self.cap_ln and abs(line_x-gfx.mouse_x)<10 then 
-             if Wave:mouseDown() or Wave:mouseR_Down() then self.cap_ln = i end
-          end
       end  
-end   
-    --------------------------------------------------------
-    -- Operations with captured lines(if exist) ------------
-    --------------------------------------------------------
-    Gate_Gl:manual_Correction()
-    -- Update captured state if mouse released -------------
-    if self.cap_ln and Wave:mouseUp() then self.cap_ln = false  
-    end     
-end
-----------------------------------------------------------------------------------------------------------------------
 
+end   
+
+end -- function Gate_Gl:draw_Lines()
+----------------------------------------------------------------------------------------------------------------------
 function Gate_Gl:draw_Ruler()
-  --if not self.Res_Points or #self.Res_Points==0 then return end -- return if no lines
-  if not self.Res_Points then return end -- return if no lines
     --------------------------------------------------------
     -- Set values ------------------------------------------
     --------------------------------------------------------
@@ -5633,56 +5739,49 @@ function Gate_Gl:draw_Ruler()
     self.start_smpl = Wave.Pos/Wave.X_scale    -- Стартовая позиция отрисовки в семплах!
     self.Xsc = Wave.X_scale * Wave.Zoom * Z_w  -- x scale(regard zoom) for trigg lines
     --------------------------------------------------------
-  
+
     -- Draw Project Grid lines ("Ruler") ----------------------------
 -------------------------------------------------------------------------------------------------------------
-
-local Grid_Points_Ruler = Grid_Points_Ruler or {};     
+local Grid_Points_Ruler = Grid_Points or {};     
 local _, division, swingmode, swingamt = r.GetSetProjectGrid(0, 0)
-local tempo_corr = 1/(r.Master_GetTempo()/120)
+if division < 0.0078125 then division = 0.0078125 end
 local lnt_corr = (loop_length/tempo_corr)/8
-
-gfx.set(0, 0, 0, 0.8) -- gate line, point color background
-
- for i=1, #Grid_Points_Ruler  do
-
-         sw_shift = swingamt*(1-abs(division-1))
-         if IsEven(i) == false and swingmode == 1 then 
-           sw_shift = (sw_shift*128*Wave.Zoom*Z_w)/lnt_corr
-             else
-           sw_shift = 0
-         end
-
-         local line_x  = Wave.x+sw_shift + (Grid_Points_Ruler[i] - self.start_smpl) * self.Xsc  -- line x coord
-         --------------------
-         -- draw line -----
-         ----------------------      
-         if line_x>=Wave.x and line_x<=Wave.x+Wave.w then -- Verify line range
-          gfx.line(line_x-1, (Wave.y*1.17), line_x-1, Wave.y-2+(Wave.h/300))  -- Draw Trig Line Left
-          gfx.line(line_x, (Wave.y*1.18), line_x, Wave.y-2+(Wave.h/300))  -- Draw Trig Line Center
-          gfx.line(line_x+1, (Wave.y*1.17), line_x+1, Wave.y-2+(Wave.h/300))  -- Draw Trig Line Right
-         end
-end  
-
-gfx.set(0.1, 1, 0.1, 1) -- gate line, point color -- цвет линий сетки проекта
+local ruler_recolor, p_corr, sw_shift = 0, 1, 0
+if 0.00007 > self.Xsc*division then self.Xsc = 0.00007/division; ruler_recolor = 1 end
 
  for i=1, #Grid_Points_Ruler  do
 
+   if Swing_on == 1 and swing_slider_amont ~= 0 then
          sw_shift = swingamt*(1-abs(division-1))
          if IsEven(i) == false and swingmode == 1 then 
             sw_shift = (sw_shift*128*Wave.Zoom*Z_w)/lnt_corr
               else
             sw_shift = 0
          end
+    end
 
-         local line_x  = Wave.x+sw_shift + (Grid_Points_Ruler[i] - self.start_smpl) * self.Xsc  -- line x coord
+         if OffsSldCorr == nil then OffsSldCorr = Offset_Sld.form_val/1000*srate end
+         local line_x  = Wave.x+sw_shift + (Grid_Points_Ruler[i] - self.start_smpl-OffsSldCorr) * self.Xsc  -- line x coord
+
          --------------------
          -- draw line -----
          ----------------------      
          if line_x>=Wave.x and line_x<=Wave.x+Wave.w then -- Verify line range
+
+             if ruler_recolor == 0 then
+                 gfx.set(0, 0, 0, 0.8) -- ruler black background
+                 gfx.rect(line_x-1,(Wave.y*1.02), 3, 3+(Wave.h/50), true) -- draw body
+               else
+                 gfx.set(0.1, 1, 0.1, 0.4) -- ruler green background ("grid too small")
+                 gfx.rect(line_x-2,(Wave.y*1.02), 5, 3+(Wave.h/50), false) -- draw body
+             end
+
+            gfx.set(0.1, 1, 0.1, 1) -- ruler green short line, point color -- цвет линий сетки проекта
             gfx.line(line_x, (Wave.y*1.17), line_x, Wave.y-1+(Wave.h/300))  -- Draw Trig Line
-         end
+
+        end
    end  
+
 end
 
 --------------------------------------------------------------------------------
@@ -5758,14 +5857,129 @@ end
 ---  GetSet_MIDITake  ----------------------------------------------------------
 --------------------------------------------------------------------------------
 -- Создает новый айтем для фичи Trigger
+
 function Wave:GetSet_MIDITake()
-    local tracknum, midi_track, item, take      
+
+    local tracknum, midi_track, item, take, track_check, startppq_time, endppq_time, count_items_on_track, item2   
+    local waveitem = 0
+
+        r.Main_OnCommand(r.NamedCommandLookup('_SWS_SAVESEL'), 0)  -- Save track selection
+
         tracknum = r.GetMediaTrackInfo_Value(self.track, "IP_TRACKNUMBER")
-        r.InsertTrackAtIndex(tracknum, false)
+
+        if Create_Replace.norm_val == 1 then r.InsertTrackAtIndex(tracknum, false) end
+
         midi_track = r.GetTrack(0, tracknum)
         r.TrackList_AdjustWindows(0)
-        item = r.CreateNewMIDIItemInProj(midi_track, self.sel_start, self.sel_end, false)
-        take = r.GetActiveTake(item)
+
+
+        r.Main_OnCommand(r.NamedCommandLookup("_SWS_SAVEALLSELITEMS1"),0) -- SWS: Save selected item(s)
+
+-------------------------check item below and select--------------------------------------------------------
+
+        r.Main_OnCommand(r.NamedCommandLookup("_SWS_RESTTIME2"),0) -- Restore time selection
+
+       if midi_track then
+
+               r.Main_OnCommand(40289, 0) -- unselect all items
+               GetLoopTimeRange()
+
+               r.SetOnlyTrackSelected(midi_track)
+                       
+                count_items_on_track = reaper.CountTrackMediaItems(midi_track)
+       
+                for i=0, count_items_on_track-1 do -- try to select item below
+                   item2 = reaper.GetTrackMediaItem(midi_track, i)          
+                       if item2 then;
+                               item_pos =  r.GetMediaItemInfo_Value( item2, 'D_POSITION' )
+                               item_length = r.GetMediaItemInfo_Value( item2, 'D_LENGTH' )
+                               item_end = item_pos + item_length
+                              if (item_pos >= self.sel_start and item_pos < self.sel_end) or (item_end <= self.sel_end and item_end > self.sel_start) or (item_pos < self.sel_start and item_end > self.sel_end) then
+                                     r.SetMediaItemSelected(item2, true)
+                                     take = r.GetActiveTake(item2)
+                                     if take then
+                                           if not r.TakeIsMIDI(take) then waveitem = 1  end --set status if wave item below
+                                     end
+                              end
+                        end
+                end
+              ---------------------------------------------------------------------------
+               if not r.GetSelectedMediaItem(0, 0) then -- create new item if none
+                  local track2, newitem
+                  track2 = r.GetSelectedTrack(0, 0)
+                  newitem = r.CreateNewMIDIItemInProj(track2, self.sel_start, self.sel_end, false) 
+                  r.SetMediaItemInfo_Value(newitem, "B_UISEL", 1)
+               end
+       end
+
+----------------------------------------------------------------------------------------------------------------
+
+     track_check = r.GetMediaTrackInfo_Value(r.GetSelectedTrack(0, 0), "IP_TRACKNUMBER") -- if no track or wave item below
+
+          if tracknum == track_check or waveitem == 1 then 
+                      if Midi_Sampler.norm_val == 2 or Midi_Sampler.norm_val == 3 then
+                         r.InsertTrackAtIndex(tracknum, false) -- create new track
+                      end
+                  midi_track = r.GetTrack(0, track_check)
+                  r.Main_OnCommand(40419, 0) -- select item below
+                  r.Main_OnCommand(r.NamedCommandLookup("_SWS_RESTTIME2"),0) -- Restore time selection
+                  r.Main_OnCommand(40718, 0) -- select item in time selection
+          end 
+
+
+          if waveitem == 1 then -- create new item on new track if wave item below
+                  trackx = reaper.GetSelectedTrack(0, 0)
+                  tracknum2 = r.GetMediaTrackInfo_Value(trackx, "IP_TRACKNUMBER")
+                  midi_track2 = r.GetTrack(0, tracknum2-2)
+                  midiItem =   r.CreateNewMIDIItemInProj(midi_track2, self.sel_start, self.sel_end, false)
+                  r.SetMediaItemInfo_Value(midiItem, "B_UISEL", 1)
+          end
+
+------------------------------------------------- Del old notes ---------------------------------------------
+
+        item = r.GetSelectedMediaItem(0, 0)
+
+        if item then 
+             if tracknum == track_check then 
+                 item = r.CreateNewMIDIItemInProj(midi_track, self.sel_start, self.sel_end, false)
+             end
+           take = r.GetActiveTake(item) 
+             else
+           item = r.CreateNewMIDIItemInProj(midi_track, self.sel_start, self.sel_end, false)
+           take = r.GetActiveTake(item)
+        end
+
+            if take and r.TakeIsMIDI(take) then
+               local ret, notecnt, ccevtcnt, textsyxevtcnt = r.MIDI_CountEvts(take)
+               local note = 0
+                -- Del old notes --
+                for i=1, notecnt do
+                    local ret, sel, muted, startppq, endppq, chan, pitch, vel = r.MIDI_GetNote(take, note)
+
+                    startppq_time = reaper.MIDI_GetProjTimeFromPPQPos(take, startppq)
+                    endppq_time = reaper.MIDI_GetProjTimeFromPPQPos(take, endppq)
+
+                        if Midi_Sampler.norm_val == 3 then
+                                  if pitch and (startppq_time >= self.sel_start and startppq_time <= self.sel_end) or (endppq_time <= self.sel_end and endppq_time >= self.sel_start) then -- check selection area
+                                     r.MIDI_DeleteNote(take, note); note = note-1 -- del note and update counter
+                                  end  
+                        elseif Midi_Sampler.norm_val == 2 then
+                                  local findpitch
+                                if Notes_On == 1 then
+                                    findpitch = 34 + OutNote2.norm_val  -- from checkbox
+                                    else
+                                    findpitch = 34 + OutNote2.norm_val  -- from checkbox
+                                end
+                             if (startppq_time >= self.sel_start and startppq_time <= self.sel_end) or (endppq_time <= self.sel_end and endppq_time >= self.sel_start) then
+                                  if pitch==findpitch then 
+                                     reaper.MIDI_DeleteNote(take, note); note = note-1 -- del note witch findpitch and update counter
+                                  end  
+                             end
+                        end
+                    note = note+1
+                end
+             end
+---------------------------------------------------------------------------------------------------------
         return item, take
 end
 
@@ -5784,10 +5998,11 @@ r.PreventUIRefresh(1)
 r.Main_OnCommand(r.NamedCommandLookup('_SWS_SAVESEL'), 0)  -- Save track selection
 
 sel_tracks_items() -- select for a multitrack check
+UnSelectMIDIAndEmptyItems()
 selected_tracks_count = r.CountSelectedTracks(0)
 count_itms =  r.CountSelectedMediaItems(0)
 
-   if count_itms == 0 then return end -- take reverse check
+if count_itms ~= 0 then  
    for i = 0, count_itms-1 do -- take fx check
    local item = r.GetSelectedMediaItem(0, i)
    local take_count = r.CountTakes(item)
@@ -5801,6 +6016,7 @@ count_itms =  r.CountSelectedMediaItems(0)
        end
      end
    end
+end -- take reverse check
 
 if SliceQ_Status == 1 and count_itms > selected_tracks_count  then
  r.Main_OnCommand(40029, 0)  -- Undo
@@ -5849,10 +6065,6 @@ if count_itms == selected_tracks_count and selected_tracks_count >1 then  -- mul
                r.Main_OnCommand(r.NamedCommandLookup("_SWS_RESTTIME2"),0);  -- Restore Selection
                r.Main_OnCommand(40061, 0) -- Item: Split items at time selection
 
-        if RE_Status == 1 then
-         re_createRE()
-         end
-
 sel_tracks_items() 
 
 unselect_if_out_of_time_range()
@@ -5866,10 +6078,6 @@ elseif count_itms > selected_tracks_count and selected_tracks_count >1 then  -- 
                r.Main_OnCommand(r.NamedCommandLookup("_SWS_SAVETIME1"),0)
                r.Main_OnCommand(r.NamedCommandLookup("_SWS_RESTTIME2"),0);  -- Restore Selection
                r.Main_OnCommand(40061, 0) -- Item: Split items at time selection
-
-        if RE_Status == 1 then
-         re_createRE()
-         end
 
 sel_tracks_items() 
 
@@ -5896,10 +6104,12 @@ if count_itms > selected_tracks_count and selected_tracks_count > 1 then  -- sli
 
  if Slice_Init_Status == 0 then---------------------------------glue------------------------------
 
-          r.Main_OnCommand(41588, 0) -- glue 
+          GlueMultitrack() -- glue 
 
    Wave:Destroy_Track_Accessor() -- Destroy previos AA
    if Wave:Create_Track_Accessor() then Wave:Processing() end
+   
+   InitTrackItemName()
 
 end
 
@@ -5922,7 +6132,7 @@ if count_itms > selected_tracks_count and selected_tracks_count >1 or count_itms
 
 end -- вторая проверка. Если айтемы не склеились, значит слайсы квантованы и применяем undo.
 
-if count_itms > 1 and selected_tracks_count >1 then  -- multitrack
+if (count_itms > 1 and selected_tracks_count > 1) and GroupingWhenSlicing == 1 then  -- multitrack
 
        r.Main_OnCommand(40032, 0) -- Group Items
 
@@ -5950,11 +6160,13 @@ local cursorpos = r.GetCursorPosition()
          local points_cnt = #Gate_Gl.Res_Points
          for i = 1, points_cnt, 2 do
              
-           if i<points_cnt then next_startppqpos = (self.sel_start + Gate_Gl.Res_Points[i]/srate )         
+           if i<points_cnt then next_startppqpos = (self.sel_start + Gate_Gl.Res_Points[i]/srate)         
             end
 
          if Midi_sampler_offs_stat == 1 then
-            cutpos = next_startppqpos - 0.002
+            cutpos = next_startppqpos - 0.002 -- -2ms
+            elseif Pitch_Det_offs_stat == 1 then
+            cutpos = next_startppqpos + 0.001 -- +1ms
             else
             cutpos = next_startppqpos
          end
@@ -6005,19 +6217,22 @@ end
          
    else
 
-   Grid_Points = Grid_Points or {}
-     local _, division, swingmode, swingamt = r.GetSetProjectGrid(0, 0)
-     local tempo_corr = 1/(r.Master_GetTempo()/120)
-    for i=1, #Grid_Points or 0 do --split by grid 
+ Grid_Points_S = Grid_Points_S or {}
+ local sw_shift = 0
+ local _, division, swingmode, swingamt = r.GetSetProjectGrid(0, 0)
 
+    for i=1, #Grid_Points_S or 0 do --split by grid 
+
+   if Swing_on == 1 and swing_slider_amont ~= 0 then
          sw_shift = swingamt*(1-abs(division-1))
          if IsEven(i) == false and swingmode == 1 then 
-         sw_shift = sw_shift*tempo_corr                    
-         else
-         sw_shift = 0
+             sw_shift = sw_shift*tempo_corr                    
+             else
+             sw_shift = 0
          end
+    end
                
-            r.SetEditCurPos((Grid_Points[i]/srate)+sw_shift,0,0)  
+            r.SetEditCurPos((Grid_Points_S[i]/srate)+(0.5/1000)+sw_shift,0,0)
                 if ZeroCrossings == 1 then
                     if ZeroCrossingType == 1 then
                          r.Main_OnCommand(41995, 0)   -- move to nearest zero crossing
@@ -6042,7 +6257,7 @@ r.Main_OnCommand(40034, 0)  ---select all items in groups
  r.PreventUIRefresh(-1)
     -------------------------------------------
     r.Undo_EndBlock("Slice", -1) 
- 
+
 end
 ::yyy::
 
@@ -6079,8 +6294,6 @@ if SliceQ_Init_Status == 1 then
  r.PreventUIRefresh(1)
    -------------------------------------------
 
- count_itms =  r.CountSelectedMediaItems(0)
-
        _, save_project_grid, save_swing, save_swing_amt = r.GetSetProjectGrid(proj, false) -- backup current grid settings
 
     if save_project_grid > 0.5 then
@@ -6105,6 +6318,7 @@ while(true) do
   i=i+1
   local item = r.GetSelectedMediaItem(0,i-1)
   if item then
+
         pos = r.GetMediaItemInfo_Value(item, "D_POSITION") + r.GetMediaItemInfo_Value(item, "D_SNAPOFFSET")
 
 if r.GetToggleCommandState(r.NamedCommandLookup('_BR_OPTIONS_SNAP_FOLLOW_GRID_VIS'), 0) == 1 then
@@ -6133,6 +6347,7 @@ end
     break
   end
 
+
  if  grid_opt == 0 then r.Main_OnCommand(r.NamedCommandLookup('_BR_OPTIONS_SNAP_FOLLOW_GRID_VIS'), 0) end
  if  snap == 0 then r.Main_OnCommand(1157, 0) end
  if  grid == 0 then r.Main_OnCommand(40145, 0) end
@@ -6149,40 +6364,6 @@ if XFadeOff == 0 then
 
   r.Main_OnCommand(r.NamedCommandLookup("_SWS_AWFILLGAPSQUICK"),0) -- fill gaps 
 
-        CrossfadeT = x_fade
-
-    local function Overlap(CrossfadeT);
-        local t,ret = {};
-        local items_count = r.CountSelectedMediaItems(0);
-        if items_count == 0 then return 0 end;
-        for i = 1 ,items_count do;
-            local item = r.GetSelectedMediaItem(0,i-1);
-            local trackIt = r.GetMediaItem_Track(item);
-            if t[tostring(trackIt)] then;
-                ----
-                ret = 1;
-                local crossfade_time = (CrossfadeT or 0)/1000;
-                local take = r.GetActiveTake(item); 
-                local pos = r.GetMediaItemInfo_Value(item,'D_POSITION');
-                local length = r.GetMediaItemInfo_Value( item,'D_LENGTH');
-                local SnOffs = r.GetMediaItemInfo_Value( item,'D_SNAPOFFSET');
-                local rateIt = r.GetMediaItemTakeInfo_Value(take,'D_PLAYRATE');
-                local ofSetIt = r.GetMediaItemTakeInfo_Value(take,'D_STARTOFFS');
-
-                if pos < crossfade_time then crossfade_time = pos end;
-                ----
-                r.SetMediaItemInfo_Value(item,'D_POSITION',pos-crossfade_time);
-                r.SetMediaItemInfo_Value(item,'D_LENGTH',length+crossfade_time);
-                r.SetMediaItemTakeInfo_Value(take,'D_STARTOFFS',ofSetIt-(crossfade_time*rateIt));
-                r.SetMediaItemInfo_Value(item,'D_SNAPOFFSET',SnOffs+crossfade_time);
-            else;
-                t[tostring(trackIt)] = trackIt;
-            end;
-        end;
-        if ret == 1 then r.Main_OnCommand(41059,0) end;
-        return ret or 0;
-    end;
-    
     r.Undo_BeginBlock();
     local Over = Overlap(CrossfadeT);
     r.Undo_EndBlock("Overlap",Over-Over*2);
@@ -6221,6 +6402,7 @@ r.PreventUIRefresh(1)
 r.Main_OnCommand(r.NamedCommandLookup('_SWS_SAVESEL'), 0)  -- Save track selection
 
 sel_tracks_items() -- select for a multitrack check
+UnSelectMIDIAndEmptyItems()
 selected_tracks_count = r.CountSelectedTracks(0)
 count_itms =  r.CountSelectedMediaItems(0)
 
@@ -6245,10 +6427,6 @@ if count_itms == selected_tracks_count and selected_tracks_count >1 then  -- mul
                r.Main_OnCommand(r.NamedCommandLookup("_SWS_RESTTIME2"),0);  -- Restore Selection
                r.Main_OnCommand(40061, 0) -- Item: Split items at time selection
 
-        if RE_Status == 1 then
-         re_createRE()
-         end
-
 sel_tracks_items() 
 
 unselect_if_out_of_time_range()
@@ -6262,10 +6440,6 @@ elseif count_itms > selected_tracks_count and selected_tracks_count >1 then  -- 
                r.Main_OnCommand(r.NamedCommandLookup("_SWS_SAVETIME1"),0)
                r.Main_OnCommand(r.NamedCommandLookup("_SWS_RESTTIME2"),0);  -- Restore Selection
                r.Main_OnCommand(40061, 0) -- Item: Split items at time selection
-
-        if RE_Status == 1 then
-         re_createRE()
-         end
 
 sel_tracks_items() 
 
@@ -6315,14 +6489,6 @@ sel_tracks_items()
      end
  count_itms =  r.CountSelectedMediaItems(0)
 
-function collect_itemtake_param()    -- collect parameter on sel item and active take for SM tables and displacement calcs...
-   selected_tracks_count = r.CountSelectedTracks(0)
-   sel_item = r.GetSelectedMediaItem(0, 0)    -- get selected item 
-   number_of_takes =  r.CountSelectedMediaItems(0)
-   if number_of_takes == 0 then return end
-   active_take = r.GetActiveTake(sel_item)  -- active take in item
- end
- 
    collect_itemtake_param()              -- get bunch of parameters about this item (inc take playrate, I lifted this from another PL9 script)
 
 
@@ -6382,19 +6548,20 @@ r.PreventUIRefresh(1)
             r.Main_OnCommand(r.NamedCommandLookup("_SWS_RESTTIME1"),0)
 
      else -- Add Markers by Grid
+ local sw_shift = 0
+ local _, division, swingmode, swingamt = r.GetSetProjectGrid(0, 0)
+      for i=1, #Grid_Points_S do
 
-    local _, division, swingmode, swingamt = r.GetSetProjectGrid(0, 0)
-    local tempo_corr = 1/(r.Master_GetTempo()/120)
-      for i=1, #Grid_Points do
-
+   if Swing_on == 1 and swing_slider_amont ~= 0 then
          sw_shift = swingamt*(1-abs(division-1))
          if IsEven(i) == false and swingmode == 1 then 
-         sw_shift = sw_shift*tempo_corr                    
-         else
-         sw_shift = 0
+             sw_shift = sw_shift*tempo_corr                    
+             else
+             sw_shift = 0
          end
+    end
        
-            r.SetEditCurPos((Grid_Points[i]/srate)+sw_shift,0,0)
+            r.SetEditCurPos((Grid_Points_S[i]/srate)+sw_shift,0,0)
         
             r.Main_OnCommand(41842, 0)  ---Add Marker
        
@@ -6450,6 +6617,29 @@ r.PreventUIRefresh(1)
 local i=0;
 
     r.Undo_BeginBlock();
+
+if r.GetToggleCommandState(r.NamedCommandLookup('_BR_OPTIONS_SNAP_FOLLOW_GRID_VIS'), 0) == 1 then
+      grid_opt = 1
+  else
+      grid_opt = 0
+      r.Main_OnCommand(r.NamedCommandLookup('_BR_OPTIONS_SNAP_FOLLOW_GRID_VIS'), 0)
+end
+
+if r.GetToggleCommandState(1157) == 1 then
+      snap = 1
+  else
+      snap = 0
+      r.Main_OnCommand(1157, 0)
+end
+
+if r.GetToggleCommandState(40145) == 1 then
+      grid = 1
+  else
+      grid = 0
+      r.Main_OnCommand(40145, 0)
+end
+
+
 while(true) do;
   i=i+1;
   local item = r.GetSelectedMediaItem(0,i-1);
@@ -6460,22 +6650,28 @@ while(true) do;
     if item then;
         local posIt = r.GetMediaItemInfo_Value(item,"D_POSITION");
         local take = r.GetActiveTake(item); 
-        local rateIt = r.GetMediaItemTakeInfo_Value(take,'D_PLAYRATE');
-        ---
-        local countStrMar = r.GetTakeNumStretchMarkers(take);
-        for i = 1,countStrMar do;
-            local pos = ({r.GetTakeStretchMarker(take,i-1)})[2]/rateIt+posIt;
-            local posGrid = Arc_GetClosestGridDivision(pos);
-            if q_force < 0 then q_force = 0 elseif q_force > 100 then q_force = 100 end;
-            local new_pos = (((posGrid-pos)/100*q_force)+pos)-posIt; 
-            r.SetTakeStretchMarker(take,i-1,new_pos*rateIt);
-        end;
+        if take then
+            local rateIt = r.GetMediaItemTakeInfo_Value(take,'D_PLAYRATE');
+            ---
+            local countStrMar = r.GetTakeNumStretchMarkers(take);
+            for i = 1,countStrMar do;
+                local pos = ({r.GetTakeStretchMarker(take,i-1)})[2]/rateIt+posIt;
+                local posGrid = Arc_GetClosestGridDivision(pos);
+                if q_force < 0 then q_force = 0 elseif q_force > 100 then q_force = 100 end;
+                local new_pos = (((posGrid-pos)/100*q_force)+pos)-posIt; 
+                r.SetTakeStretchMarker(take,i-1,new_pos*rateIt);
+            end;
+        end
         r.UpdateItemInProject(item);
     end;
   else;
     break;
   end;
 end;
+
+ if  grid_opt == 0 then r.Main_OnCommand(r.NamedCommandLookup('_BR_OPTIONS_SNAP_FOLLOW_GRID_VIS'), 0) end
+ if  snap == 0 then r.Main_OnCommand(1157, 0) end
+ if  grid == 0 then r.Main_OnCommand(40145, 0) end
 
     r.Undo_EndBlock("MarkersQ",-1);
 
@@ -6531,14 +6727,6 @@ end
 sel_tracks_items() 
 count_itms =  r.CountSelectedMediaItems(0)
 
-function collect_itemtake_param()    -- collect parameter on sel item and active take for SM tables and displacement calcs...
-   selected_tracks_count = r.CountSelectedTracks(0)
-   sel_item = r.GetSelectedMediaItem(0, 0)    -- get selected item 
-   number_of_takes =  r.CountSelectedMediaItems(0)
-   if number_of_takes == 0 then return end
-   active_take = r.GetActiveTake(sel_item)  -- active take in item
- end
- 
    collect_itemtake_param()              -- get bunch of parameters about this item (inc take playrate, I lifted this from another PL9 script)
 
 take_check()
@@ -6559,16 +6747,18 @@ local timer = 2 -- Time in seconds
 local time = reaper.time_precise()
 local function Msg()
    local char = gfx.getchar()
-     if char == 27 or char == -1 or (reaper.time_precise() - time) > timer then ErrMsg_Ststus = 0 return end
-local Get_Sel_ErrMsg = ErrMsg:new(680,450+corrY,260,25, 1, 1, 1, 1, "Something went wrong. Use Undo (Ctrl+Z)",    "Arial", 22)
+     if char == 27 or char == -1 or (reaper.time_precise() - time) > timer then ErrMsg_Status = 0 return end
+local Get_Sel_ErrMsg = ErrMsg:new(580,35,260,45, 1, 1, 1, 1, "Something went wrong. Use Undo (Ctrl+Z)")
 local ErrMsg_TB = {Get_Sel_ErrMsg}
-ErrMsg_Ststus = 1
+ErrMsg_Status = 1
      for key,btn    in pairs(ErrMsg_TB)   do btn:draw()    
    gfx.update()
   r.defer(Msg)
 end
 end
+if ErrMsg_Status ~= 1 then
 Msg()
+end
 
 ---------------------------------End of Error Message----------------------------------------------
 Init()
@@ -6690,6 +6880,9 @@ function ExportItemToRS5K_defaults(data,conf,refresh,note,filepath, start_offs, 
     if start_offs and end_offs then
       r.TrackFX_SetParamNormalized( track, rs5k_pos, 13, start_offs ) -- attack
       r.TrackFX_SetParamNormalized( track, rs5k_pos, 14, end_offs )   
+        if ForcePitchBend == 1 then
+              r.TrackFX_SetParamNormalized( track, rs5k_pos, 16, (1/12)*PitchBend ) -- pitch bend
+        end
     end  
   end
 
@@ -6870,12 +7063,102 @@ if  Take_Check == 0 then Load() end --
 
 end
 
+
+-------------------------------------------------------------------
+function TransposeNotesToKickSnareHat()
+
+HatThreshold = HatThreshold -- velocity. Lowest vel becomes to hat, highest becomes to snare.
+local KickNote = 35
+local SnareNote = 38
+local HatNote = 42
+
+local collect_pitch = {}
+local retval, ret, sel, muted, startppq, endppq, chan, pitch, vel
+ local item = r.GetSelectedMediaItem(0, 0)
+       if item then take = r.GetActiveTake(item) 
+
+                               item_pos =  r.GetMediaItemInfo_Value( item, 'D_POSITION' )
+                               item_length = r.GetMediaItemInfo_Value( item, 'D_LENGTH' )
+                               item_end = item_pos + item_length
+
+            if take and r.TakeIsMIDI(take) then
+                 r.MIDI_DisableSort(take)
+                 local _, notecnt = r.MIDI_CountEvts(take)
+                 local note = 0
+                 -----------------collect loudest notes to table-----------------------------
+                  for i=1, notecnt do
+                      ret, sel, muted, startppq, endppq, chan, pitch, vel = r.MIDI_GetNote(take, note)
+                      if pitch and vel > HatThreshold then 
+                           collect_pitch[i] = pitch
+                      end  
+                      note = note+1
+                  end
+
+
+ ----------------------------------- find lowest note---------------------------------
+           local key, min = 1, collect_pitch[1]
+           for k, v in ipairs(collect_pitch) do
+               if collect_pitch[k] < min then
+                   min = v
+               end
+           end
+
+              GetLoopTimeRange()
+            
+                  if (item_pos >= start and item_pos <= ending) or (item_end <= ending and item_end >= start) or (item_pos < start and item_end > ending) then
+                  --------------------------------------set new pitch-----------------------------------
+                            local _, notes = r.MIDI_CountEvts(take)
+                            for i = 0, notes-1 do
+                              retval, sel, muted, startppq, endppq, chan, pitch, vel = r.MIDI_GetNote(take, i)
+                              if min then
+                                   r.MIDI_SetNote(take, i, sel, muted, startppq, endppq, chan, pitch+(KickNote-min), vel) -- kick and overal transpose
+                               end
+                               if vel <= HatThreshold then
+                                   r.MIDI_SetNote(take, i, sel, muted, startppq, endppq, chan, HatNote, vel) -- hat
+                               end
+                            end
+                  
+                  --------------------------------------set new pitch 2nd pass------------------------
+                            local _, notes = r.MIDI_CountEvts(take)
+                            for i = 0, notes-1 do
+                              retval, sel, muted, startppq, endppq, chan, pitch, vel = r.MIDI_GetNote(take, i)
+                                    if pitch < 37 then
+                                       r.MIDI_SetNote(take, i, sel, muted, startppq, endppq, chan, KickNote, vel) -- any lowest to kick
+                                    end
+                               if vel > HatThreshold then
+                                    if pitch >= 37 then
+                                       r.MIDI_SetNote(take, i, sel, muted, startppq, endppq, chan, SnareNote, vel) -- snare
+                                    end
+                                end
+                            end
+                  
+                  --------------------------------------set vel 100 if Velocity Off------------------------
+                           if Pitch_Det_Options.norm_val ~= 1 and (Pitch_Preset.norm_val == 1 or Pitch_Preset.norm_val == 2) then 
+                                 local _, notes = r.MIDI_CountEvts(take)
+                                 for i = 0, notes-1 do
+                                   retval, sel, muted, startppq, endppq, chan, pitch, vel = r.MIDI_GetNote(take, i)
+                                   r.MIDI_SetNote(take, i, sel, muted, startppq, endppq, chan, pitch, 100) -- set vel 100
+                                 end
+                           end
+                  end
+            
+  
+      r.MIDI_Sort(take)  
+      r.UpdateItemInProject(item)
+   end
+r.UpdateArrange()
+end
+
+end
+
+
 --------------------------------------------------------------------------------
 ---  Create MIDI  --------------------------------------------------------------
 --------------------------------------------------------------------------------
 -- Создает миди-ноты в соответствии с настройками и полученными из аудио данными
 function Wave:Create_MIDI()
   r.Undo_BeginBlock() 
+  r.PreventUIRefresh(1) 
   -------------------------------------------
     local item, take = Wave:GetSet_MIDITake()
     if not take then return end 
@@ -6913,8 +7196,293 @@ function Wave:Create_MIDI()
     Trigg_Status = 1
     Reset_Status = 0
   -------------------------------------------
+  r.Main_OnCommand(r.NamedCommandLookup('_SWS_RESTALLSELITEMS1'), 0) -- SWS: Restore saved selected item(s)
+  r.Main_OnCommand(40635, 0) -- Time selection: Remove (unselect) time selection
+  r.Main_OnCommand(r.NamedCommandLookup('_SWS_RESTORESEL'), 0)  -- Restore track selection
+
+  r.SetEditCurPos(cursorpos,0,0) 
+
+  r.PreventUIRefresh(-1)
   r.Undo_EndBlock("Create Trigger MIDI", -1) 
 end
+------------------------------------------------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+---  Create Pitched MIDI  --------------------------------------------------------------
+--------------------------------------------------------------------------------
+
+function Wave:Detect_pitch()
+
+     r.Undo_BeginBlock() 
+
+         local peakrate
+         local peakrate2 = 200
+         local item_table = {p0sition_id, note_id, duration_id, vel_id, a_end, power}
+
+         local attThresh_dB = -6  -- curve level above which the script turns on 
+         local relThresh_dB = -12  -- curve level below which the script turns off
+
+
+
+         if Pitch_Preset.norm_val == 1 then
+             pitch_preset = 0.025 -- Drums
+             peakrate = 1000
+             HatThreshold = 70
+             elseif Pitch_Preset.norm_val == 2 then
+             pitch_preset = 0.005 -- Drums 2
+             peakrate = 1000
+             HatThreshold = 85
+             attThresh_dB = -6
+             relThresh_dB = -14
+             elseif Pitch_Preset.norm_val == 3 then
+             pitch_preset = 0.005 -- Percussion
+             peakrate = 1000
+             attThresh_dB = -6
+             relThresh_dB = -16
+             elseif Pitch_Preset.norm_val == 4 then
+             pitch_preset = 0.0626 -- Bass
+             peakrate = 100 
+             elseif Pitch_Preset.norm_val == 5 then
+             pitch_preset = 0.0626 -- Default
+             peakrate = 1000
+             elseif Pitch_Preset.norm_val == 6 then
+             pitch_preset = 0.04 -- Melodic
+             peakrate = 1000
+             elseif Pitch_Preset.norm_val == 7 then
+             pitch_preset = 0.1 -- Complex
+             peakrate = 100
+             else
+             pitch_preset = 0.0626
+             peakrate = 1000
+         end
+
+                    local nn = pitch_preset*tempo_corr 
+                    local buffsize = srate/50 
+
+                    relThresh  = 10^(relThresh_dB/20)
+                    attThresh  = 10^(attThresh_dB/20)
+                    
+          local n_spls, want_extra_type, buf2, retval2
+
+          function FrequencyToName_Drums(f)
+              local n = {'1', '1', '1', '1', '1', '1', '1', '2', '2', '2', '3', '3',
+                              '3', '4', '4', '4', '5', '5', '5', '6', '6', '6', '7', '7',
+                             '7', '8', '8', '8', '9', '9', '9', '10', '10', '10', '11', '11',
+                             '11', '12', '12', '12', '13', '13', '13', '14', '14', '14', '15', '15',
+                             '15', '16', '16', '16', '17', '17', '17', '18', '18', '18', '19', '19',
+                             '19', '20', '20', '20', '21', '21', '21', '22', '22', '22', '23', '23',
+                             '23', '24', '24', '24', '25', '25', '25', '26', '26', '26', '27', '27',
+                             '27', '28', '28', '28', '29', '29', '29', '30', '30', '30', '31', '31',
+                             '31', '32', '32', '32', '33', '33', '33', '34', '34', '34', '35', '35',
+                             '35', '36', '36', '36', '37', '37', '37', '38', '38', '38', '39', '39',
+                             '39', '40', '40', '40', '41', '41', '41', '42', '42', '42', '42', '42'}
+              local dist = (132 * logx(f / 6.875) / logx(2048) % 132)
+              local dist_rnd = floor(dist + 0.5) % 132
+              return n[dist_rnd + 1]+18
+          end
+
+          function FrequencyToName(f)
+              local n = {'-3', '-2', '-1', '0', '1', '2', '3', '4', '5', '6', '7', '8',
+                              '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20',
+                             '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32',
+                             '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44',
+                             '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56',
+                             '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68',
+                             '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80',
+                             '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92',
+                             '93', '94', '95', '96', '97', '98', '99', '100', '101', '102', '103', '104',
+                             '105', '106', '107', '108', '109', '110', '111', '112', '113', '114', '115', '116',
+                             '117', '118', '119', '120', '121', '122', '123', '124', '125', '126', '127', '128'}
+              local dist = (132 * logx(f / 6.875) / logx(2048) % 132)
+              local dist_rnd = floor(dist + 0.5) % 132
+              return n[dist_rnd + 1]
+          end
+
+---------------------------------------------
+  local items = r.CountSelectedMediaItems(0)
+
+     for i=0, items-1 do
+     
+        item = r.GetSelectedMediaItem(0,i);
+          
+           if item then
+
+                    take = r.GetActiveTake( item )
+     
+                    p0sition = r.GetMediaItemInfo_Value(item, "D_POSITION")
+                    l3ngth = r.GetMediaItemInfo_Value(item, "D_LENGTH")
+                    note_duration = p0sition+l3ngth
+                    note_duration_halved = p0sition+(l3ngth/2)
+
+               if take then
+
+       -------------------------------------------Vel detection -------------------------------------------------------------
+            if Pitch_Det_Options.norm_val == 1 or Pitch_Preset.norm_val == 1 or Pitch_Preset.norm_val == 2 then
+                     local source = r.GetMediaItemTake_Source(take)    
+                     local accessor = r.CreateTakeAudioAccessor(take)
+                     local channels = 1 -- r.GetMediaSourceNumChannels(source)
+                     local buffer = r.new_array(srate*channels)
+                     r.GetAudioAccessorSamples(accessor, srate, channels, 0.005, 1000, buffer)
+
+                     local sampleMax = 0
+                
+                     for j = 1, buffsize do                               
+                        local spls = abs(buffer[j])                 
+                        sampleMax = max(spls, sampleMax)
+                     end
+                     
+                     note_velocity = min(floor(logx(sampleMax+0.2)*50)+110, 127)
+       
+                     r.DestroyAudioAccessor(accessor)
+               else
+                     note_velocity = 100       
+             end
+
+       ------------------------------------------Pitch detection------------------------------------------------------------
+                    local buf = r.new_array(3);
+                    buf.clear()
+
+                    local rv = r.GetMediaItemTake_Peaks(take, peakrate, p0sition+nn, 1, 1, 115, buf);
+                    if rv & (1<<24) and (rv&0xfffff) > 0 then
+                      local spl = buf[3];
+                      note_tonal = spl&0x7fff
+                      power = (spl>>15)/16384.0;
+                    end
+
+                 --   if power < 0.01 then note_tonal = nil end
+
+                    if note_tonal ~= nil and note_tonal > 5 then -- and note_tonal > 5
+                         if Pitch_Preset.norm_val == 1 or Pitch_Preset.norm_val == 2 then
+                             note_name = FrequencyToName_Drums(note_tonal) --create note from frequency
+                             else
+                             note_name = FrequencyToName(note_tonal) --create note from frequency
+                         end
+                    end
+
+      ----------------------------------------Length detection------------------------------------------------------------
+                    if Pitch_Det_Options2.norm_val == 1 then
+                                n_spls = ceil(l3ngth*peakrate2) -- Note: its Peak Samples!
+                              
+                                buf2 = r.new_array(n_spls * 2) -- max, min, only for 1 channel
+                                buf2.clear()         -- Clear buffer
+                                retval2 = r.GetMediaItemTake_Peaks(take, peakrate2, p0sition, 1, n_spls, 0, buf2)
+                                ------------------
+                              
+                                local last_trig = false
+                                for m = 1, n_spls do
+                                    max_peak = max(abs(buf2[m]), abs(buf2[m+n_spls]))
+                              
+                                        if not last_trig and max_peak >= attThresh then
+                                          last_trig = true
+                                        elseif last_trig and max_peak < relThresh then
+                                          a_ending = p0sition + (m-1)/peakrate2; last_trig = false
+          
+                                        end
+                                end
+                     end
+                      ------------------      
+                 end 
+          end
+
+        if a_ending == nil then a_ending = note_duration_halved end
+        if a_ending <= p0sition then a_ending = note_duration_halved end
+     
+        item_table[i] = {
+               p0sition_id = p0sition,
+               note_id = note_name,
+               duration_id = note_duration,   
+               vel_id = note_velocity,  
+               a_end = a_ending,
+               pow = power      
+               }
+
+     end
+
+-----------------
+local items = r.CountSelectedMediaItems(0) --reset takes vol
+for i=0, items-1 do 
+ local item = r.GetSelectedMediaItem(0, i)
+     local take = r.GetActiveTake(item)
+         r.SetMediaItemTakeInfo_Value(take, 'D_VOL', 1)
+end
+------------------
+
+----------------------------------Create MIDI-------------------------------------------------------------------------
+         local item, take = Wave:GetSet_MIDITake()
+         if not take then return end 
+
+         r.MIDI_DisableSort(take)
+
+          local next_startppqpos, p0sition2, note2, duration2, velocity2, a_end2, fix_length, detect_ppqpos2, pow2
+
+           if (Guides.norm_val == 1) then -- staccato note length in Transient mode
+                  fix_length = 240
+                     else  -- staccato note length in Grid mode (half grid)
+                  local _, division, _, _ = r.GetSetProjectGrid(0,false)
+                  fix_length = division*1920 
+           end
+
+      local items_t = #item_table 
+          if items_t ~= 0 then
+                   for k=0, items_t do  
+                                         p0sition2 = item_table[k].p0sition_id       
+                                         note2 = item_table[k].note_id  
+                                         duration2 =  item_table[k].duration_id
+                                         velocity2 =  item_table[k].vel_id
+                                         a_end2 =  item_table[k].a_end
+                                         pow2 =  item_table[k].pow
+    
+                        start_ppqpos = r.MIDI_GetPPQPosFromProjTime(take, p0sition2 )
+                        end_ppqpos = r.MIDI_GetPPQPosFromProjTime(take, duration2 )
+                        detect_ppqpos = r.MIDI_GetPPQPosFromProjTime(take, a_end2 )
+    
+                        if (Guides.norm_val == 1) then -- 
+                              detect_ppqpos2 = detect_ppqpos
+                                else -- fix note length in Grid mode 
+                              detect_ppqpos2 = start_ppqpos+fix_length
+                        end
+    
+                        if Pitch_Det_Options2.norm_val == 1 then -- length, detected
+                               note_length = detect_ppqpos
+    
+                                           ----------------del overlaps -----------
+                                               if k<items-1 then next_startppqpos = r.MIDI_GetPPQPosFromProjTime(take, item_table[k+1].p0sition_id ) -- next note position
+                                                     if next_startppqpos<detect_ppqpos then    -- del overlaps 
+                                                         note_length = min(detect_ppqpos2, next_startppqpos) 
+                                                     end
+                                               end
+                                          -----------------------------------------
+    
+                        elseif Pitch_Det_Options2.norm_val == 2 then  -- staccato, fixed
+    
+                              note_length = start_ppqpos+fix_length
+                                           ----------------del overlaps -----------
+                                               if k<items-1 then next_startppqpos = r.MIDI_GetPPQPosFromProjTime(take, item_table[k+1].p0sition_id ) -- next note position
+                                                     if next_startppqpos<start_ppqpos+fix_length then    -- del overlaps 
+                                                         note_length = min(end_ppqpos, next_startppqpos)-10
+                                                     end
+                                               end
+                                           if note_length > start_ppqpos+240 then note_length = start_ppqpos+240 end -- length limiter
+                                          -----------------------------------------
+                            elseif Pitch_Det_Options2.norm_val == 3 then  -- legato
+                               note_length = end_ppqpos-2
+                        end
+    
+                         if k == 0 and velocity2 < 35 then note2 = nil end
+                   --      if k == 0 and pow2 < 0.6  then note2 = nil end
+    
+                            if note2 then
+                                r.MIDI_InsertNote(take, 1, 0, start_ppqpos, note_length, 0, note2, velocity2, true)
+                            end
+    
+                    end -- end of Create MIDI
+         end
+         
+                        r.MIDI_Sort(take)           -- sort notes
+                        r.UpdateItemInProject(item) -- update item
+
+    if Pitch_Preset.norm_val == 1 or Pitch_Preset.norm_val == 2 then TransposeNotesToKickSnareHat() end
+
+end -- end of function Wave:Detect_pitch()
 
 --------------------------------------------------------------------------------
 ---  Accessor  -----------------------------------------------------------------
@@ -6931,14 +7499,9 @@ function Wave:Create_Track_Accessor()
       local tk = r.GetActiveTake(item)
       if tk then
 
-      r.GetMediaItemTake_Track(tk)  
-    
     self.track = r.GetMediaItemTake_Track(tk)
     if self.track then self.AA = r.CreateTrackAudioAccessor(self.track)
 
-         self.AA_Hash  = r.GetAudioAccessorHash(self.AA, "")
-         self.AA_start = r.GetAudioAccessorStartTime(self.AA)
-         self.AA_end   = r.GetAudioAccessorEndTime(self.AA)
          self.buffer   = r.new_array(block_size)-- main block-buffer
          self.buffer.clear()
          return true
@@ -6963,7 +7526,7 @@ function Wave:Get_TimeSelection()
 
  local item = r.GetSelectedMediaItem(0,0)
     if item then
-      local start, ending = r.GetSet_LoopTimeRange( 0, 0, 0, 0, 0 )
+      GetLoopTimeRange()
       if start ~= ending then
           time_sel_length = ending - start
           else
@@ -6988,16 +7551,18 @@ local timer = 2 -- Time in seconds
 local time = reaper.time_precise()
 local function Msg()
    local char = gfx.getchar()
-     if char == 27 or char == -1 or (reaper.time_precise() - time) > timer then ErrMsg_Ststus = 0 return end
-local Get_Sel_ErrMsg = ErrMsg:new(680,450+corrY,260,25, 1, 1, 1, 1, "Item is Too Short (<0.25s)",    "Arial", 22)
+     if char == 27 or char == -1 or (reaper.time_precise() - time) > timer then ErrMsg_Status = 0 return end
+local Get_Sel_ErrMsg = ErrMsg:new(580,35,260,45, 1, 1, 1, 1, "Item is Too Short (<0.25s)")
 local ErrMsg_TB = {Get_Sel_ErrMsg}
-ErrMsg_Ststus = 1
+ErrMsg_Status = 1
      for key,btn    in pairs(ErrMsg_TB)   do btn:draw()    
    gfx.update()
   r.defer(Msg)
 end
 end
+if ErrMsg_Status ~= 1 then
 Msg()
+end
 --------------------------------------End of Error Message-------------------------------------
 Init()
 end
@@ -7025,7 +7590,6 @@ end
 --- Draw Original,Filtered -----------------------------------------------------
 --------------------------------------------------------------------------------
 function Wave:Redraw()
- 
     local x,y,w,h = self.def_xywh[1],self.def_xywh[2],self.def_xywh[3],self.def_xywh[4]
     ---------------
     gfx.dest = 1           -- set dest gfx buffer1
@@ -7046,6 +7610,7 @@ end
 --------------------------------------------------------------
 --------------------------------------------------------------
 function Wave:draw_waveform(mode, r,g,b,a)
+
     local Peak_TB, Ysc
     local Y = self.Y
     ----------------------------
@@ -7079,11 +7644,13 @@ function Wave:draw_waveform(mode, r,g,b,a)
         gfx.line(i,y, i,y2) -- здесь всегда x=i
     end  
     ----------------------------
+
 end
 
 --------------------------------------------------------------
 --------------------------------------------------------------
 function Wave:Create_Peaks(mode) -- mode = 1 for original, mode = 2 for filtered
+--local start_time = reaper.time_precise()
     local buf
     if mode==1 then buf = self.in_buf    -- for input(original)    
                else buf = self.out_buf   -- for output(filtered)
@@ -7112,6 +7679,7 @@ function Wave:Create_Peaks(mode) -- mode = 1 for original, mode = 2 for filtered
     ----------------------------
     if mode==1 then self.in_peaks = Peak_TB else self.out_peaks = Peak_TB end    
     ----------------------------
+--reaper.ShowConsoleMsg("Full Process time = " .. reaper.time_precise()-start_time .. '\n') -- time test 
 end
 
 
@@ -7141,7 +7709,10 @@ function Wave:Set_Values()
     self.sel_len    = min(self.sel_len,time_limit)     -- limit lenght(deliberate restriction) 
     self.selSamples = floor(self.sel_len*srate)        -- time selection lenght to samples
     -- init Horizontal --------------
-    self.max_Zoom = 150 -- maximum zoom level(желательно ок.150-200,но зав. от длины выдел.(нужно поправить в созд. пиков!))
+
+    local MaxZoom = 5*self.sel_len
+    if MaxZoom > 150 then MaxZoom = 150 end
+    self.max_Zoom = MaxZoom -- maximum zoom level(желательно ок.150-200,но зав. от длины выдел.(нужно поправить в созд. пиков!))
     self.Zoom = self.Zoom or 1  -- init Zoom 
     self.Pos  = self.Pos  or 0  -- init src position
     -- init Vertical ---------------- 
@@ -7149,13 +7720,13 @@ function Wave:Set_Values()
     self.vertZoom = self.vertZoom or 1  -- init vertical Zoom 
     ---------------------------------
     -- pix_dens - нужно выбрать оптимум или оптимальную зависимость от sel_len!!!
-    self.pix_dens = 8            -- 2^(4-1) 4-default. 1-учесть все семплы для прорисовки(max кач-во),2-через один и тд.
+    self.pix_dens = 4            -- 2^(4-1) 4-default. 1-учесть все семплы для прорисовки(max кач-во),2-через один и тд.
     self.X, self.Y  = x, h/2                           -- waveform position(X,Y axis)
     self.X_scale    = w/self.selSamples                -- X_scale = w/lenght in samples
     self.Y_scale    = h/2.5                            -- Y_scale for waveform drawing
     ---------------------------------
     -- Some other values ------------
-    self.crsx   = block_size/16   -- one side "crossX"  -- use for discard some FFT artefacts(its non-nat, but in this case normally)
+    self.crsx   = ceil(block_size/16)   -- one side "crossX"  -- use for discard some FFT artefacts(its non-nat, but in this case normally)
     self.Xblock = block_size-self.crsx*2               -- active part of full block(use mid-part of each block)
     -----------
     local max_size = 2^22 - 1    -- Макс. доступно(при создании из таблицы можно больше, но...)
@@ -7173,9 +7744,10 @@ end
 
 -----------------------------------
 function Wave:Processing()
-    -------------------------------
+--local start_time = reaper.time_precise()
+    -----------------------------
     -- Filter values --------------
-    -------------------------------
+    -----------------------------
     -- LP = HiFreq, HP = LowFreq --
     local Low_Freq, Hi_Freq =  HP_Freq.form_val, LP_Freq.form_val
     local bin_freq = srate/(block_size*2)          -- freq step 
@@ -7185,19 +7757,19 @@ function Wave:Processing()
     lowband = floor(lowband/2)*2
     hiband  = ceil(hiband/2)*2  
     -------------------------------------------------------------------------
-    -- Get Original(input) samples to in_buf >> to table >> create peaks ----
+    -- Get Original(input) samples to in_buf >> to table >> create peaks ---
     -------------------------------------------------------------------------
     if not self.State then
         if not self:Set_Values() then return end -- set main values, coordinates etc   
         ------------------------------------------------------ 
         local size = self.full_buf_sz
         local buf_start = self.sel_start
-				local max = self.n_Full_Bufs+1
-				local tmp_buf = r.new_array(size)
-				local len = self.full_buf_sz/srate
+        local max = self.n_Full_Bufs+1
+        local tmp_buf = r.new_array(size)
+        local len = self.full_buf_sz/srate
         for i=1, max do 
             if i == max then size = self.rest_buf_sz end  
-						tmp_buf.clear()
+            tmp_buf.clear()
             r.GetAudioAccessorSamples(self.AA, srate, 1, buf_start, size, tmp_buf) -- orig samples to in_buf for drawing
             --------
             if i==1 then self.in_buf = tmp_buf.table(1,size) else self:table_plus(1, (i-1)*self.full_buf_sz, tmp_buf.table(1,size) ) end
@@ -7210,14 +7782,14 @@ function Wave:Processing()
     end
     
     -------------------------------------------------------------------------
-    -- Filtering >> samples to out_buf >> to table >> create peaks ----------
+    -- Filtering >> samples to out_buf >> to table >> create peaks --------
     -------------------------------------------------------------------------
     local size, n_XBlocks = self.full_buf_sz, self.n_XBlocks_FB
     local buf_start = self.sel_start
     local max = self.n_Full_Bufs+1
-		local tmp_buf = r.new_array(size)
-		local len = self.full_buf_sz/srate
-		for i=1, max do
+    local tmp_buf = r.new_array(size)
+    local len = self.full_buf_sz/srate
+    for i=1, max do
        if i == max then size, n_XBlocks = self.rest_buf_sz, self.n_XBlocks_RB end
        ------
        ---------------------------------------------------------
@@ -7227,9 +7799,9 @@ function Wave:Processing()
                -- Filter_FFT ----(note: don't use out of range freq!)
                -----------------------------------------------------------           
                       local buf = self.buffer
-                        ----------------------------------------
-                        -- Filter(use fft_real) --------------
-                        ----------------------------------------
+                        -----------------------------------
+                        -- Filter(use fft_real) -------------
+                        -----------------------------------
                         buf.fft_real(block_size,true)       -- FFT
                           -----------------------------
                           -- Clear lowband bins --
@@ -7255,22 +7827,25 @@ function Wave:Processing()
     -------------------------------------------------------------------------
     self.State = true -- Change State
     -------------------------
+    collectgarbage() -- collectgarbage(подметает память) 
+--reaper.ShowConsoleMsg("Full Process time = " .. reaper.time_precise()-start_time .. '\n') -- time test 
 end 
 
 
 ----------------------------------------------------------------------------------------------------
 ----------------------------------------------------------------------------------------------------
----  Wave - Get - Set Cursors  ---------------------------------------------------------------------
+---  Wave - Get - Set Cursors  --------------------------------------------------------------------
 ----------------------------------------------------------------------------------------------------
 function Wave:Get_Cursor() 
   local E_Curs = r.GetCursorPosition()
   --- edit cursor ---
   local insrc_Ecx = (E_Curs - self.sel_start) * srate * self.X_scale    -- cursor in source!
+     insrc_Ecx_k = insrc_Ecx
      self.Ecx = (insrc_Ecx - self.Pos) * self.Zoom*Z_w                  -- Edit cursor
      if self.Ecx >= 0 and self.Ecx <= self.w then gfx.set(0.7,0.8,0.9,1) -- main edit cursor color
         gfx.line(self.x + self.Ecx, self.y, self.x + self.Ecx, self.y+self.h -1 )
      end
-     if self.Ecx >= 0 and self.Ecx <= self.w then gfx.set(0.9,0.9,0.9,1) -- loop edit cursor color 
+     if self.Ecx >= 0 and self.Ecx <= self.w then gfx.set(1,1,1,1) -- loop edit cursor color 
         gfx.line(self.x + self.Ecx, self.y/1.5, self.x + self.Ecx, (self.y+self.h)/9.3 )
      end
   --- play cursor ---
@@ -7343,9 +7918,12 @@ end
     --- Wave get-set Cursors ----
     self:Get_Cursor()
     self:Set_Cursor()   
+
+self.insrc_mx_zoom_k = self.Pos + (insrc_Ecx_k-self.x)/(self.Zoom*Z_w) -- its current cursor position in source!
     -----------------------------------------
     --- Wave Zoom(horizontal) ---------------
     if self:mouseIN() and gfx.mouse_wheel~=0 and not(Ctrl or Shift) then 
+DrawGridGuides()
     local M_Wheel = gfx.mouse_wheel
       -------------------
       if     M_Wheel>0 then self.Zoom = min(self.Zoom*1.25, self.max_Zoom)   
@@ -7358,7 +7936,6 @@ end
 self_Zoom = self.Zoom --refresh loop by mw
       -------------------
       Wave:Redraw() -- redraw after horizontal zoom
-DrawGridGuides()
     end
     -----------------------------------------
     --- Wave Zoom(Vertical) -----------------
@@ -7438,6 +8015,7 @@ end
     if Ctrl and self:mouseM_Down() then 
       self.Pos = 0
       self.Zoom = 1   
+      Wave:Redraw() -- redraw after zoom reset
       --------------------
     end
 
@@ -7450,10 +8028,7 @@ end
      --------------------------------------------------------------------------------
      -- Zoom by Arrow Keys
      --------------------------------------------------------------------------------
-local KeyUP
-local KeyDWN
-local KeyL
-local KeyR
+local KeyUP, KeyDWN, KeyL, KeyR
 
     if char==30064 then KeyUP = 1 else KeyUP = 0 end -- up
     if char==1685026670 then KeyDWN = 1 else KeyDWN = 0 end -- down
@@ -7463,33 +8038,27 @@ local KeyR
 -------------------------------horizontal----------------------------------------
      if  KeyR == 1 then self.Zoom = min(self.Zoom*1.2, self.max_vertZoom+138)   
 
-      self.Pos = self.insrc_mx_zoom - (gfx.mouse_x-self.x)/(self.Zoom*Z_w)
+      self.Pos = self.insrc_mx_zoom_k - (insrc_Ecx_k-(self.x*1.2))/(self.Zoom*Z_w)
       self.Pos = max(self.Pos, 0)
       self.Pos = min(self.Pos, (self.w - self.w/self.Zoom)/Z_w )
 
      Wave:Redraw() -- redraw after horizontal zoom
-     else
-     end   
+        
+     elseif  KeyL == 1 then self.Zoom = max(self.Zoom*0.8, 1)
 
-     if  KeyL == 1 then self.Zoom = max(self.Zoom*0.8, 1)
-
-      self.Pos = self.insrc_mx_zoom - (gfx.mouse_x-self.x)/(self.Zoom*Z_w)
+      self.Pos = self.insrc_mx_zoom_k - (insrc_Ecx_k-(self.x*0.8))/(self.Zoom*Z_w)
       self.Pos = max(self.Pos, 0)
       self.Pos = min(self.Pos, (self.w - self.w/self.Zoom)/Z_w )
 
      Wave:Redraw() -- redraw after horizontal zoom
-     else
      end   
 
 -------------------------------vertical-------------------------------------------
      if  KeyUP == 1 then self.vertZoom = min(self.vertZoom*1.2, self.max_vertZoom)   
      Wave:Redraw() -- redraw after vertical zoom
-     else
-     end   
 
-     if  KeyDWN == 1 then self.vertZoom = max(self.vertZoom*0.8, 1)
+     elseif  KeyDWN == 1 then self.vertZoom = max(self.vertZoom*0.8, 1)
      Wave:Redraw() -- redraw after vertical zoom
-     else
      end   
 
 end
@@ -7502,20 +8071,14 @@ function Wave:from_gfxBuffer()
   if not Z_w or not Z_h then return end -- return if zoom not defined
   self.x, self.w = (self.def_xywh[1]* Z_w) , (self.def_xywh[3]* Z_w) -- upd x,w
   self.y, self.h = (self.def_xywh[2]* Z_h) , (self.def_xywh[4]* Z_h) -- upd y,h
-  if self.fnt_sz then --fix it!--
-     self.fnt_sz = max(16,self.def_xywh[5]* (Z_w+Z_h)/1.9)
-     self.fnt_sz = min(22,self.fnt_sz* Z_h)
-  end 
+
   -- draw Wave frame, axis -------------
   self:draw_rect()
-
 
    -- Insert Wave from gfx buffer1 ------
   gfx.a = 1 -- gfx.a for blit
   local srcw, srch = Wave.def_xywh[3], Wave.def_xywh[4] -- its always def values 
-    if WFiltering == 0 then
-        gfx.mode = 4
-    end
+    if WFiltering == 0 then gfx.mode = 4 end
   gfx.blit(1, 1, 0, 0, 0, srcw, srch,  self.x, self.y, self.w, self.h)
 
   -- Get Mouse -------------------------
@@ -7563,6 +8126,48 @@ end
   ]]) 
 end
 
+function Wave:show_process_wait()
+
+      if Wave.State then     
+             local Get_Sel_ErrMsg = ErrMsg:new(580,35,260,45, 1, 1, 1, 1, "Processing, wait...")
+             local ErrMsg_TB = {Get_Sel_ErrMsg}
+             ErrMsg_Status = 1
+                  for key,btn    in pairs(ErrMsg_TB)   do btn:draw()    
+             end           
+       else           
+             local fnt_sz = 100
+             if gfx.ext_retina == 1 then
+              fnt_sz = max(14,  fnt_sz* (Z_h)/2)
+              fnt_sz = min(80, fnt_sz* Z_h)
+             else
+              fnt_sz = max(17,  fnt_sz* (Z_h)/2)
+              fnt_sz = min(96, fnt_sz* Z_h)
+             end
+             
+              gfx.setfont(1, "Arial", fnt_sz)
+              gfx.set(0.6, 0.6, 0.6, 1) -- цвет текста инфо
+              local ZH_correction = Z_h*40
+              gfx.x, gfx.y = self.x+23 * (Z_w+Z_h)-ZH_correction, (self.y+1*(Z_h*3))+120
+             
+              gfx.drawstr("Processing, wait...", 1, gfx.w, gfx.h)
+       end
+end
+
+
+function Wave:show_init_track_item_name()
+
+if TableTI.item == '' then TableTI.item = 'NoName' end
+
+      if TableTI.track and TableTI.item then    
+             local text_sys = TextShort(TableTI.item, 50)
+             local Get_Sel_SysMsg = SysMsg:new(550,15,470,20, 1, 1, 1, 1, "Track ".. TableTI.track ..",  Item: ".. text_sys .."")
+             local SysMsg_TB = {Get_Sel_SysMsg}
+             if ShowTrackAndItemInfo == 1 then
+                  for key,btn    in pairs(SysMsg_TB)   do btn:draw()   end      
+             end
+       end
+end
+
 ----------------------------------------------------------------------------------------------------
 ---   MAIN   ---------------------------------------------------------------------------------------
 ----------------------------------------------------------------------------------------------------
@@ -7573,11 +8178,11 @@ function MAIN()
           Wave:from_gfxBuffer() -- Wave from gfx buffer
           Gate_Gl:draw_Lines()  -- Draw Gate trig-lines
       --       for key,btn    in pairs(Ruler_TB)   do btn:draw()    end   -- Draw Ruler Background
-          Gate_Gl:draw_Ruler() -- Draw Ruler lines
-
+         if ShowRuler == 1 then Gate_Gl:draw_Ruler() end -- Draw Ruler lines
 
 
         local _, division, swing, _ = r.GetSetProjectGrid(0,false)
+        if division < 0.0078125 then division = 0.0078125 end
 -----------------------------Grid Buttons Leds-------------------------------------------------------
         if division == 1 or division == 2/3 then
                  for key,frame  in pairs(Grid1_Led_TB)    do frame:draw()  end  
@@ -7607,7 +8212,7 @@ function MAIN()
                  for key,frame  in pairs(Grid64_Led_TB)    do frame:draw()  end  
         Grid64_on = 0
         end
-           if ((floor(1/division+.5)) % 3) == 0 then Trplts = true else Trplts = false end;
+           if (1//division) % 3 == 0 then Trplts = true else Trplts = false end;
         if GridT_on == 1 or Trplts == true then
                  for key,frame  in pairs(GridT_Led_TB)    do frame:draw()  end  
         end
@@ -7639,6 +8244,7 @@ function MAIN()
           end
       else 
           Wave:show_help()      -- else show help
+
     end
 
   -- Draw sldrs, btns etc ------
@@ -7683,6 +8289,15 @@ if  Random_Setup ~= 1 then
       if (Midi_Sampler.norm_val == 1)  then
          for key,ch_box    in pairs(Checkbox_TB_preset)   do ch_box:draw()    end 
       end
+
+     if Midi_Sampler.norm_val == 1 then
+         for key,frame  in pairs(MIDI_Mode_Color1_TB)    do frame:draw()  end 
+     elseif Midi_Sampler.norm_val == 2 then
+         for key,frame  in pairs(MIDI_Mode_Color2_TB)    do frame:draw()  end 
+     elseif Midi_Sampler.norm_val == 3 then
+         for key,frame  in pairs(MIDI_Mode_Color3_TB)    do frame:draw()  end 
+     end
+
 end
       if (Midi_Sampler.norm_val == 2)then 
            if  Random_Setup ~= 1 then
@@ -7693,15 +8308,18 @@ end
                  for key,sldr   in pairs(Slider_TB_Trigger)   do sldr:draw()   end
               end
            end
-         if Guides.norm_val ~= 1 then
-               for key,frame  in pairs(Frame_TB2_Trigg)    do frame:draw()  end 
-         end
      else
          if  Random_Setup ~= 1 then
-               for key,frame  in pairs(Preset_TB)    do frame:draw()  end  
+              for key,frame  in pairs(Preset_TB)    do frame:draw()  end 
+                   if Midi_Sampler.norm_val == 3 then
+                        for key,frame  in pairs(Pitch_Det_Options_TB)    do frame:draw()  end  
+                   end  
          end
      end
 
+                   if (Midi_Sampler.norm_val == 3 or Midi_Sampler.norm_val == 2) and Random_Setup ~= 1 then        
+                        for key,frame  in pairs(Create_Replace_TB)    do frame:draw()  end 
+                  end
 
      if Guides.norm_val == 1  then
         for key,frame  in pairs(Frame_TB1)    do frame:draw()  end   
@@ -7721,39 +8339,47 @@ end
 
         for key,frame  in pairs(Triangle_TB)    do frame:draw()  end 
 
-      if Random_Order == 1 then
-         for key,frame  in pairs(Rand_Mode_Color1_TB)    do frame:draw()  end 
-     end
-      if Random_Vol == 1 then
-         for key,frame  in pairs(Rand_Mode_Color2_TB)    do frame:draw()  end 
-         for key,sldr   in pairs(SliderRandV_TB)   do sldr:draw()   end
-     end
-      if Random_Pan == 1 then
-         for key,frame  in pairs(Rand_Mode_Color3_TB)    do frame:draw()  end 
-         for key,sldr   in pairs(SliderRandPan_TB)   do sldr:draw()   end
-     end
-      if Random_Pitch == 1 then
-         for key,frame  in pairs(Rand_Mode_Color4_TB)    do frame:draw()  end 
-         for key,sldr   in pairs(SliderRandPtch_TB)   do sldr:draw()   end
-     end
-      if Random_Mute == 1 then
-         for key,frame  in pairs(Rand_Mode_Color7_TB)    do frame:draw()  end 
-     end
-      if Random_Position == 1 then
-         for key,frame  in pairs(Rand_Mode_Color6_TB)    do frame:draw()  end 
-         for key,sldr   in pairs(SliderRand_TBPos)   do sldr:draw()   end
-     end
-      if Random_Reverse == 1 then
-         for key,frame  in pairs(Rand_Mode_Color5_TB)    do frame:draw()  end 
-         for key,sldr   in pairs(SliderRand_TBM)   do sldr:draw()   end
-     end
+       if Random_Order == 1 then
+          for key,frame  in pairs(Rand_Mode_Color1_TB)    do frame:draw()  end 
+      end
+       if Random_Vol == 1 then
+          for key,frame  in pairs(Rand_Mode_Color2_TB)    do frame:draw()  end 
+          for key,sldr   in pairs(SliderRandV_TB)   do sldr:draw()   end
+      end
+       if Random_Pan == 1 then
+          for key,frame  in pairs(Rand_Mode_Color3_TB)    do frame:draw()  end 
+          for key,sldr   in pairs(SliderRandPan_TB)   do sldr:draw()   end
+      end
+       if Random_Pitch == 1 then
+          for key,frame  in pairs(Rand_Mode_Color4_TB)    do frame:draw()  end 
+          for key,sldr   in pairs(SliderRandPtch_TB)   do sldr:draw()   end
+      end
+       if Random_Mute == 1 then
+          for key,frame  in pairs(Rand_Mode_Color7_TB)    do frame:draw()  end 
+      end
+       if Random_Position == 1 then
+          for key,frame  in pairs(Rand_Mode_Color6_TB)    do frame:draw()  end 
+          for key,sldr   in pairs(SliderRand_TBPos)   do sldr:draw()   end
+      end
+       if Random_Reverse == 1 then
+          for key,frame  in pairs(Rand_Mode_Color5_TB)    do frame:draw()  end 
+          for key,sldr   in pairs(SliderRand_TBM)   do sldr:draw()   end
+      end
 
          for key,frame  in pairs(RandText_TB)    do frame:draw()  end 
    end
 
+     if Guides.norm_val ~= 1 and Midi_Sampler.norm_val == 2 and Random_Setup ~= 1 then
+           for key,frame  in pairs(Frame_TB2_Trigg)    do frame:draw()  end -- mode fill
+     end
+
     if ShowInfoLine == 1 and Random_Setup ~= 1 then
         Info_Line()
     end
+
+     if ErrMsg_Status == 0 and Random_Setup ~= 1 then
+          Wave:show_init_track_item_name()
+     end
 
 end
 
@@ -7761,55 +8387,213 @@ end
 -- MouseWheel Related Functions ---
 ------------------------------------
 
-function MW_doit_slider()
+function MW_doit_slider(mwsl)
+
+      local div
+      if mwsl == 1 then
+        div = 400
+        elseif  mwsl == 0 or mwsl == nil then
+        div = 5000
+      end
+
       if Wave.State then
-            Gate_Gl:Apply_toFiltered() -- redraw transient markers
-            Slice_Status = 1
+
+           if (ending and start) and ending - start > 45 then
+
+               time_c = (ending - start)/div
+               if time_c > 1.0 then time_c = 1.0 end
+
+                   time_start = reaper.time_precise()   
+                   local function Main_d()    
+                       local elapsed = reaper.time_precise() - time_start       
+                       if elapsed >= time_c then
+                            ErrMsg_Status = 0
+                       ----------------------------------------------------------------
+                       Gate_Gl:Apply_toFiltered() -- redraw transient markers
+                       Slice_Status = 1
+                        ---------------------------------------------------------------
+                         runcheckd = 0
+                           return
+                       else
+                          ------------------------------
+                          ErrMsg_Status = 1
+                          Wave:show_process_wait()
+                          ------------------------------
+                         runcheckd = 1
+                           reaper.defer(Main_d)
+                       end           
+                   end
+                   if runcheckd ~= 1 then
+                      Main_d()
+                   end----------------------------------
+           else
+                       Gate_Gl:Apply_toFiltered() -- redraw transient markers
+                       Slice_Status = 1
+           end
+
       end
 end
 
-function MW_doit_slider_Fine()
+function MW_doit_slider_Fine(mwsf)
+
+      local div
+      if mwsf == 1 then
+        div = 400
+        elseif  mwsf == 0 or mwsf == nil then
+        div = 5000
+      end
+
       if Wave.State then
-            Gate_Gl:Apply_toFiltered() -- redraw transient markers
-            DrawGridGuides()
-            Slice_Status = 1
+
+           if (ending and start) and ending - start > 45 then
+
+               time_c = (ending - start)/div
+               if time_c > 1.0 then time_c = 1.0 end
+                   time_start = reaper.time_precise()   
+                   local function Main_d()    
+                       local elapsed = reaper.time_precise() - time_start       
+                       if elapsed >= time_c then
+                            ErrMsg_Status = 0
+                       ----------------------------------------------------------------
+                        OffsSldCorr = (Offset_Sld.form_val/1000*srate)
+                        Gate_Gl:Apply_toFiltered()
+                        DrawGridGuides()
+                        Slice_Status = 1
+                        ---------------------------------------------------------------
+                         runcheckd = 0
+                           return
+                       else
+                          ------------------------------
+                          ErrMsg_Status = 1
+                          Wave:show_process_wait()
+                          ------------------------------
+                         runcheckd = 1
+                           reaper.defer(Main_d)
+                       end           
+                   end
+                   if runcheckd ~= 1 then
+                      Main_d()
+                   end----------------------------------
+           else
+                  OffsSldCorr = (Offset_Sld.form_val/1000*srate)
+                  Gate_Gl:Apply_toFiltered()
+                  DrawGridGuides()
+                  Slice_Status = 1
+           end
+
       end
 end
 
 function MW_doit_slider_Swing()
-        time_start = reaper.time_precise()       
-        local function Mainz()     
-            local elapsed = reaper.time_precise() - time_start       
-            if elapsed >= 0.1 then
-                --
-              runcheck = 0
-                return
-            else         
-        r.GetSetProjectGrid(0, true, division, swing_mode, swing_slider_amont) --
-              runcheck = 1
-                reaper.defer(Mainz)
-            end           
-        end
-        
-   if runcheck ~= 1 then
-      Mainz()
-   end
+   if Wave.State then
+           time_start = reaper.time_precise()       
+           local function Mainz()     
+               local elapsed = reaper.time_precise() - time_start       
+               if elapsed >= 0.2 then
+                   --
+                 runcheck = 0
+                   return
+               else         
+           r.GetSetProjectGrid(0, true, division, swing_mode, swing_slider_amont) --
+                 runcheck = 1
+                   reaper.defer(Mainz)
+               end           
+           end
+           
+      if runcheck ~= 1 then
+         Mainz()
+      end
+  end
 end
 
-function MW_doit_slider_fgain()
+function MW_doit_slider_fgain(mwfg)
+
+      local div
+      if mwfg == 1 then
+        div = 400
+        elseif  mwfg == 0 or mwfg == nil then
+        div = 4000
+      end
+
       if Wave.State then
-            Gate_Gl:Apply_toFiltered() -- redraw transient markers
-            Wave:Redraw() --redraw filtered gain and filters
-            Slice_Status = 1
+
+            if (ending and start) and ending - start > 30 then
+
+               time_c = (ending - start)/div
+               if time_c > 1.0 then time_c = 1.0 end
+
+                    time_start = reaper.time_precise()   
+                    local function Main_f()    
+                        local elapsed = reaper.time_precise() - time_start       
+                        if elapsed >= time_c then
+                             ErrMsg_Status = 0
+                        ----------------------------------------------------------------
+                        Gate_Gl:Apply_toFiltered() -- redraw transient markers
+                        Wave:Redraw() --redraw filtered gain and filters
+                        Slice_Status = 1
+                         ---------------------------------------------------------------
+                          runcheckf = 0
+                            return
+                        else
+                           ------------------------------
+                           ErrMsg_Status = 1
+                           Wave:show_process_wait()
+                           ------------------------------
+                          runcheckf = 1
+                            reaper.defer(Main_f)
+                        end           
+                    end
+                    if runcheckf ~= 1 then
+                       Main_f()
+                    end----------------------------------
+            else
+                    Gate_Gl:Apply_toFiltered() -- redraw transient markers
+                    Wave:Redraw() --redraw filtered gain and filters
+                    Slice_Status = 1
+            end
+
       end
 end
 
-function MW_doit_slider_comlpex()
+function MW_doit_slider_comlpex(mw)  -- redraw lowcut and highcut
+
+      local div
+      if mw == 1 then
+        div = 200
+        elseif  mw == 0 or mw == nil then
+        div = 2000
+      end
+
       if Wave.State then
-            Wave:Processing() -- redraw lowcut and highcut
+ if (ending and start) then time_c = (ending - start)/div end
+     if time_c > 1.0 then time_c = 1.0 end
+        time_start = reaper.time_precise()   
+        local function Main_i()    
+            local elapsed = reaper.time_precise() - time_start  
+            if  elapsed >= time_c then
+
+                 ErrMsg_Status = 0
+            ----------------------------------------------------------------
+            Wave:Processing()
             Gate_Gl:Apply_toFiltered() -- redraw transient markers
             Wave:Redraw() --redraw filtered gain and filters
             Slice_Status = 1
+             ---------------------------------------------------------------
+              runchecki = 0
+                return
+            else
+               ------------------------------
+               ErrMsg_Status = 1
+               Wave:show_process_wait()
+               ------------------------------
+              runchecki = 1
+                reaper.defer(Main_i)
+            end           
+        end
+        if runchecki ~= 1 then
+           Main_i()
+        end----------------------------------
+
       end
 end
 
@@ -7833,7 +8617,7 @@ end
 end
 
 function Glue_protection() -- не клеит, если Guides активны
-   if Guides.norm_val == 1 then
+   if Guides.norm_val == 1 and Midi_Sampler.norm_val ~= 3 then
 r.Main_OnCommand(41588, 0) -- glue (если изменены rate, pitch, больше одного айтема и не миди айтем, то клей. Требуется для корректной работы кнопки MIDI).
 end 
 end
@@ -7844,6 +8628,91 @@ function MIDITrigger()
      Wave.State = false -- reset Wave.State
    end 
 end
+
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+function MIDITrigger_pitched()
+
+         tggl_state = r.GetToggleCommandState(42294)
+     
+         if tggl_state == 0 then r.Main_OnCommand(42303,0) end
+
+      --   r.ClearPeakCache()
+      --   r.Main_OnCommand(40441,0) --rebuild peaks
+
+         r.Main_OnCommand(40178, 0) -- Set take channel mode to mono (downmix)
+         r.Main_OnCommand(40108, 0) -- Normalize
+
+      ----------------add_time getting and calculation-------------------
+        lastitemq = r.GetExtState('_Slicer_', 'ItemToSlice')   
+        itemq =  r.BR_GetMediaItemByGUID( 0, lastitemq )
+       
+       sel_tracks_items()
+       local track = r.GetSelectedTrack(0,0)
+       trackID = track and r.CSurf_TrackToID( track, false )
+       local count_tracks = r.CountTracks(0)
+
+        takeq = r.GetActiveTake( itemq )
+        local source = r.GetMediaItemTake_Source(takeq) 
+        local true_length, lengthIsQN = reaper.GetMediaSourceLength(source);
+
+        at_const = TimeForPeaksRebuild
+        add_time =  at_const+(true_length)/(50/at_const) or 4 -- content processing time depends on the duration of the wav file
+      ---------------------------------------------------------------------
+       ----------------------timer-------------------------
+        local time_start = reaper.time_precise()       
+        local function Main()     
+            local elapsed = reaper.time_precise() - time_start       
+            if elapsed >= add_time then
+
+                 r.PreventUIRefresh(1)
+                 -----------------------------------------------
+                 if Wave.State then Wave:Detect_pitch() end
+                 Wave.State = false -- reset Wave.State
+                 -----------------------------------------------
+
+                 ---------------we finish what we started in GetSet_MIDITake()-----------------
+                 r.Main_OnCommand(r.NamedCommandLookup('_SWS_RESTALLSELITEMS1'), 0) -- SWS: Restore saved selected item(s)
+                 r.Main_OnCommand(40635, 0) -- Time selection: Remove (unselect) time selection
+
+                 if tggl_state == 0 then r.Main_OnCommand(42303,0) end -- 42294
+
+                 r.Main_OnCommand(40176, 0)  -- Set take channel mode to normal
+                 r.Main_OnCommand(40548, 0)  -- Heal Splits
+                 r.Main_OnCommand(r.NamedCommandLookup('_SWS_RESTORESEL'), 0)  -- Restore track selection
+                 Pitch_Det_offs_stat = 0
+                 r.SetEditCurPos(cursorpos,0,0)
+               --  r.TrackList_AdjustWindows(0) 
+
+                ------------------------------------
+                 if count_tracks == trackID then
+                 r.Main_OnCommand(40913,0)  -- Track: Vertical scroll selected tracks into view
+                 end
+                 ------------------------------------
+
+                 r.PreventUIRefresh(-1);
+                 r.UpdateArrange()
+                 ---------------------------------------------------------------
+
+              runcheck = 0
+                return
+            else
+             ---------
+              runcheck = 1
+                reaper.defer(Main)
+            end           
+        end
+        
+        if runcheck ~= 1 then
+           Main()
+        end
+        ------------------------------------------------------
+
+
+end
+
 ------------------------------------------------------------------------------------
 
 function store_settings() --store dock position
@@ -7857,6 +8726,9 @@ function store_settings2() --store sliders/checkboxes
         r.SetExtState('cool_MK Slicer.lua','OutNote.norm_val',OutNote.norm_val,true);
         r.SetExtState('cool_MK Slicer.lua','Midi_Sampler.norm_val',Midi_Sampler.norm_val,true);
         r.SetExtState('cool_MK Slicer.lua','Sampler_preset.norm_val',Sampler_preset.norm_val,true);
+        r.SetExtState('cool_MK Slicer.lua','Create_Replace.norm_val',Create_Replace.norm_val,true);
+        r.SetExtState('cool_MK Slicer.lua','Pitch_Det_Options.norm_val',Pitch_Det_Options.norm_val,true);
+        r.SetExtState('cool_MK Slicer.lua','Pitch_Det_Options2.norm_val',Pitch_Det_Options2.norm_val,true);
         r.SetExtState('cool_MK Slicer.lua','QuantizeStrength',QStrength_Sld.form_val,true);
         r.SetExtState('cool_MK Slicer.lua','HF_Slider',HP_Freq.norm_val,true);
         r.SetExtState('cool_MK Slicer.lua','LF_Slider',LP_Freq.norm_val,true);
@@ -7865,6 +8737,7 @@ function store_settings2() --store sliders/checkboxes
         if XFadeOff == 0 then
            r.SetExtState('cool_MK Slicer.lua','CrossfadeTime',XFade_Sld.form_val,true);
         end
+        r.SetExtState('cool_MK Slicer.lua','PitchDetect',Pitch_Preset.norm_val,true);
         r.SetExtState('cool_MK Slicer.lua','Gate_VeloScale.norm_val',Gate_VeloScale.norm_val,true);
         r.SetExtState('cool_MK Slicer.lua','Gate_VeloScale.norm_val2',Gate_VeloScale.norm_val2,true);
 
@@ -7897,7 +8770,7 @@ function Init()
     -- Some gfx Wnd Default Values ---------------
     local R,G,B = 45,45,45              -- 0...255 format -- цвет основного окна
     local Wnd_bgd = R + G*256 + B*65536 -- red+green*256+blue*65536  
-    local Wnd_Title = "MK Slicer v2.15"
+    local Wnd_Title = "MK Slicer v2.5"
     local Wnd_Dock, Wnd_X,Wnd_Y = dock_pos, xpos, ypos
  --   Wnd_W,Wnd_H = 1044,490 -- global values(used for define zoom level)
 
@@ -7919,9 +8792,9 @@ end
 
 function Info_Line()
        -- Draw out_gain value
-   if ErrMsg_Ststus == 1 or not Z_w or not Z_h then return end -- return if zoom not defined
+   if not Z_w or not Z_h then return end -- return if zoom not defined
        gfx.set(1,1,1,0.4)    -- set body color
-       gfx.x = gfx.x+(Z_w*64)
+       gfx.x = gfx.x+(Z_w*120)
        gfx.y = gfx.y+3
    local _, division, swing, swingamt = r.GetSetProjectGrid(0,false)
    if swingamt then
@@ -7934,7 +8807,7 @@ function Info_Line()
         local i,T,str1,str2,str3,str4;
     if  division >= 0.6 and division <= 0.7 then divisi = division/2
     else divisi = division end
-        fraction = floor(1/divisi+.5)
+        fraction = 1//divisi
         str1 = (string.format("%.0f",1).."/"..string.format("%.0f",fraction)):gsub("/%s-1$","");
         if division >= 1 then str2 = string.format("%.3f",division):gsub("[0.]-$","") else str2 = str1 end;
         if (fraction % 3) == 0 then T = true else T = false end;
@@ -7960,8 +8833,12 @@ end
 ---------------------------------------
 --   Mainloop   ------------------------
 ---------------------------------------
-
 function mainloop()
+
+local rng1x = rng1
+local rng2x = rng2
+
+local Loop_onx = Loop_on
 
     -- zoom level -- 
     Wnd_WZ = r.GetExtState("cool_MK Slicer.lua", "zoomWZ") or 1044
@@ -7971,10 +8848,11 @@ function mainloop()
 
     Z_w, Z_h = gfx.w/Wnd_WZ, gfx.h/Wnd_HZ
     gfx_width = gfx.w
-    if Z_w<0.63 then Z_w = 0.63 elseif Z_w>2.2 then Z_w = 2.2 end 
+    if Z_w<0.63 then Z_w = 0.63 elseif Z_w>4 then Z_w = 4 end --2.2
     if Z_h<0.63 then Z_h = 0.63 elseif Z_h>2.2 then Z_h = 2.2 end 
 
     -- mouse and modkeys --
+
     if gfx.mouse_cap&2==0 then mouseR_Up_status = 1 end
     if gfx.mouse_cap&1==1   and last_mouse_cap&1==0  or   -- L mouse
        gfx.mouse_cap&2==2   and last_mouse_cap&2==0  or   -- R mouse
@@ -7997,20 +8875,20 @@ function mainloop()
     -------------------------
     MAIN() -- main function
     -------------------------
-    if ShowRuler == 1 then
-        DrawGridGuides2()
-    end
 
     if Loop_on == 1 then
        isloop = true
          else
        isloop = false
-     --       if loopcheck == 0 then
-                r.GetSet_LoopTimeRange(true, true, 0, 0, false)
-      --      end
     end
 
-    if loop_start then
+
+if Loop_onx ~= Loop_on then
+                r.GetSet_LoopTimeRange(true, true, 0, 0, false) -- loop off when Loop_on == 0
+end
+
+
+    if loop_start and Wave.State and (rng1x ~= rng1 or rng2x ~= rng2) or Loop_onx ~= Loop_on then
         r.GetSet_LoopTimeRange(isloop, true, rng1, rng2, false)
     end
 
@@ -8026,15 +8904,17 @@ function mainloop()
               if rng3 == nil then rng3 = 0 end
               if rng4 == nil then rng4 = 1 end
 
-         reaper.GetSet_ArrangeView2( 0,1,0,0,rng3, rng4 )
+         r.GetSet_ArrangeView2( 0,1,0,0,rng3, rng4 )
 
     end
 
-if gfx.mouse_wheel ~= 0 then
-wheel_check = 1
-else
-wheel_check = 0
-end
+
+
+    if gfx.mouse_wheel ~= 0 then
+    wheel_check = 1
+    else
+    wheel_check = 0
+    end
 
     last_mouse_cap = gfx.mouse_cap
     last_x, last_y = gfx.mouse_x, gfx.mouse_y
@@ -8090,32 +8970,52 @@ end
 
 function getitem()
 
-    r.Undo_BeginBlock() 
-r.PreventUIRefresh(1)
-Muted = 0
-if number_of_takes == 1 and mute_check == 1 then 
-r.Main_OnCommand(40175, 0) 
-Muted = 1
-end
+     time_start = reaper.time_precise()       
+        local function Main()     
+            local elapsed = reaper.time_precise() - time_start       
+            if elapsed >= 0.01 then
+                 ErrMsg_Status = 0
+            ----------------------------------------------------------------
+                        r.Undo_BeginBlock() 
+                        r.PreventUIRefresh(1)
+                        Muted = 0
+                        if number_of_takes == 1 and mute_check == 1 then 
+                        r.Main_OnCommand(40175, 0) 
+                        Muted = 1
+                        end
+                        
+                        ----------------------------
+                           Wave:Destroy_Track_Accessor() -- Destroy previos AA(освобождает память etc)
+                           Wave.State = false -- reset Wave.State
+                           if Wave:Create_Track_Accessor() then Wave:Processing()
+                              if Wave.State then
+                                 Wave:Redraw()
+                                 Gate_Gl:Apply_toFiltered() 
+                                 DrawGridGuides()
+                              end
+                           end
+                        ----------------------------------
+                        
+                        if Muted == 1 then
+                        r.Main_OnCommand(40175, 0) 
+                        end
+                        r.PreventUIRefresh(-1)
+                        r.Undo_EndBlock("Toggle Item Mute", -1) 
+             ------------------------------------------------------------------
 
-----------------------------------------------------------------
-   Wave:Destroy_Track_Accessor() -- Destroy previos AA(освобождает память etc)
-   Wave.State = false -- reset Wave.State
-   if Wave:Create_Track_Accessor() then Wave:Processing()
-      if Wave.State then
-         Wave:Redraw()
-         Gate_Gl:Apply_toFiltered() 
-         DrawGridGuides()
-        -- DrawGridGuides2()
-      end
-   end
------------------------------------------------------------------
-
-if Muted == 1 then
-r.Main_OnCommand(40175, 0) 
-end
-r.PreventUIRefresh(-1)
-    r.Undo_EndBlock("Toggle Item Mute", -1) 
+              runcheck = 0
+                return
+            else
+            Wave:show_process_wait()
+             ErrMsg_Status = 1
+              runcheck = 1
+                reaper.defer(Main)
+            end           
+        end
+        
+        if runcheck ~= 1 then
+           Main()
+        end
 
 end
 
@@ -8174,9 +9074,9 @@ context_menu = Menu("context_menu")
 
 item1 = context_menu:add_item({label = "Links|", active = false})
 
-item2 = context_menu:add_item({label = "Donate (PayPal)", toggleable = false})
+item2 = context_menu:add_item({label = "Donate (ByMeACoffee)", toggleable = false})
 item2.command = function()
-                     r.CF_ShellExecute('https://paypal.me/MKokarev')
+                     r.CF_ShellExecute('https://www.buymeacoffee.com/MaximKokarev')
 end
 
 item3 = context_menu:add_item({label = "User Manual and Support (Forum Thread)|", toggleable = false})
@@ -8209,7 +9109,7 @@ gfx.quit()
      dock_pos = dock_pos or 1025
      xpos = 400
      ypos = 320
-     local Wnd_Title = "MK Slicer v2.15"
+     local Wnd_Title = "MK Slicer v2.5"
      local Wnd_Dock, Wnd_X,Wnd_Y = dock_pos, xpos, ypos
      gfx.init( Wnd_Title, Wnd_W,Wnd_H, Wnd_Dock, Wnd_X,Wnd_Y )
 
@@ -8221,7 +9121,7 @@ gfx.quit()
     dock_pos = 0
     xpos = r.GetExtState("cool_MK Slicer.lua", "window_x") or 400
     ypos = r.GetExtState("cool_MK Slicer.lua", "window_y") or 320
-    local Wnd_Title = "MK Slicer v2.15"
+    local Wnd_Title = "MK Slicer v2.5"
     local Wnd_Dock, Wnd_X,Wnd_Y = dock_pos, xpos, ypos
     gfx.init( Wnd_Title, Wnd_W,Wnd_H, Wnd_Dock, Wnd_X,Wnd_Y )
  
@@ -8421,6 +9321,7 @@ item19 = context_menu:add_item({label = "Reset All Setted User Defaults", toggle
 item18.command = function()
 
       r.SetExtState('cool_MK Slicer.lua','DefaultXFadeTime',15,true);
+      r.SetExtState('cool_MK Slicer.lua','DefaultP_Slider',5,true);
       r.SetExtState('cool_MK Slicer.lua','DefaultQStrength',100,true);
       r.SetExtState('cool_MK Slicer.lua','DefaultLP',1,true);
       r.SetExtState('cool_MK Slicer.lua','DefaultHP',0.3312,true);
@@ -8446,6 +9347,7 @@ item20.command = function()
 Reset_to_def = 1
   --sliders--
       DefaultXFadeTime = tonumber(r.GetExtState('cool_MK Slicer.lua','DefaultXFadeTime'))or 15;
+      DefaultP_Slider = tonumber(r.GetExtState('cool_MK Slicer.lua','DefaultP_Slider'))or 5;
       DefaultQStrength = tonumber(r.GetExtState('cool_MK Slicer.lua','DefaultQStrength'))or 100;
       DefaultHP = tonumber(r.GetExtState('cool_MK Slicer.lua','DefaultHP'))or 0.3312;
       DefaultLP = tonumber(r.GetExtState('cool_MK Slicer.lua','DefaultLP'))or 1;
@@ -8454,6 +9356,9 @@ Reset_to_def = 1
   --sheckboxes--
      DefMIDI_Mode =  1;
      DefSampler_preset_state =  1;
+     DefCreate_Replace_state =  1
+     DefPitch_Det_Options_state =  1;
+     DefPitch_Det_Options_state2 =  1;
      DefGuides_mode =  1;
      DefOutNote_State =  1;
      DefGate_VeloScale =  1;
@@ -8462,6 +9367,7 @@ Reset_to_def = 1
 
   --sliders--
       r.SetExtState('cool_MK Slicer.lua','CrossfadeTime',DefaultXFadeTime,true);
+      r.SetExtState('cool_MK Slicer.lua','PitchDetect',DefaultP_Slider,true);
       r.SetExtState('cool_MK Slicer.lua','QuantizeStrength',DefaultQStrength,true);
       r.SetExtState('cool_MK Slicer.lua','Offs_Slider',DefaultOffset,true);
       r.SetExtState('cool_MK Slicer.lua','HF_Slider',DefaultHP,true);
@@ -8473,6 +9379,9 @@ Reset_to_def = 1
       r.SetExtState('cool_MK Slicer.lua','OutNote.norm_val',DefOutNote_State,true);
       r.SetExtState('cool_MK Slicer.lua','Midi_Sampler.norm_val',DefMIDI_Mode,true);
       r.SetExtState('cool_MK Slicer.lua','Sampler_preset.norm_val',DefSampler_preset_state,true);
+      r.SetExtState('cool_MK Slicer.lua','Create_Replace.norm_val',DefCreate_Replace_state,true);
+      r.SetExtState('cool_MK Slicer.lua','Pitch_Det_Options.norm_val',DefPitch_Det_Options_state,true);
+      r.SetExtState('cool_MK Slicer.lua','Pitch_Det_Options2.norm_val',DefPitch_Det_Options_state2,true);
       r.SetExtState('cool_MK Slicer.lua','XFadeOff',DefXFadeOff,true);
       r.SetExtState('cool_MK Slicer.lua','Gate_VeloScale.norm_val',DefGate_VeloScale,true);
       r.SetExtState('cool_MK Slicer.lua','Gate_VeloScale.norm_val2',DefGate_VeloScale2,true);
@@ -8501,6 +9410,7 @@ end
 function user_defaults()
 ::first_string::
 DefaultXFadeTime = tonumber(r.GetExtState('cool_MK Slicer.lua','DefaultXFadeTime'))or 15;
+DefaultP_Slider = tonumber(r.GetExtState('cool_MK Slicer.lua','DefaultP_Slider'))or 5;
 DefaultQStrength = tonumber(r.GetExtState('cool_MK Slicer.lua','DefaultQStrength'))or 100;
 DefaultHP = tonumber(r.GetExtState('cool_MK Slicer.lua','DefaultHP'))or 0.3312;
 DefaultLP = tonumber(r.GetExtState('cool_MK Slicer.lua','DefaultLP'))or 1;


### PR DESCRIPTION
+ Added Pitch Detection mode for quick conversion of monophonic melodies and drums to MIDI.
+ The Drums preset in Pitch Detection recognizes and creates MIDI notes of Kick, Snare and Hat.
+ New overwrite mode for MIDI creation in Trigger and Pitch Detection modes.
+ Bug fixed: now the script does not crash when trying to process Empty Items.
+ Fixed a bug that slows down updating the script window when Loop is running.
+ Bug fixed: now after initializing items with a long silence at the beginning, Gain and Threshold do not take huge values.
+ Bug fixed: now if after initialization item selection disappears, all functions will still work.
+ Bug fixed: now Marker Quantize works if the visible grid is off.
+ Now when zooming horizontally with the keyboard keys, the waveform is centered on the edit cursor.
+ "Processing, wait..." message to brighten up your waiting while processing or initializing long items.
+ Service messages and caring error messages now appear at the top of the window.
+ The script runs even if the selection is not correct. No more intrusive pop-up windows. If unsuitable items are selected, the selection is removed automatically.
+ Now the script can run even on multitracks. Only the topmost selected track will be analyzed.
+ Now loop selection is not blocked and is captured by the script only at the moments of control from the Slicer interface.
+ The minimum value of the HPF slider turns off the HPF filter, completely removing filtering artifacts.
+ Limited minimum grid and ruler resolution: now long items and small grid resolutions do not overload the processor.
+ Optimization in general: now the script starts instantly. CPU load reduced by 50% in idle, memory consumption during processing and initialization is reduced.
+ Now, when initializing for multiple items, the script does not try to apply Heal by default. Glue only.
+ Smart Glue: On initialization, if a multitrack is selected, Glue happens selectively. Single items, MIDI and Empty Items are ignored.
+ Now in MIDI Trigger mode Glue will not work if the item's Rate is changed. The trigger has become non-destructive for single items.
+ Now the value of the pitch band is forced for ReaSamplomatic5000 instances. In the code, it is possible to turn off the boost or change the pitchband range.
+ After finishing MIDI processing, when no audio is loaded, loop selection is not captured by the script.
+ Improved responsiveness of sliders when using the mousewheel.
+ Increased the maximum width of the waveform window for ultra-wide screens.
+ Donate service changed to valid.