### PR TITLE
Release FX Devices v1.0beta9.2

### DIFF
--- a/FX/BryanChi_FX Devices.lua
+++ b/FX/BryanChi_FX Devices.lua
@@ -7950,7 +7950,7 @@ function loop()
                                                 Content = file:read('*a')       local Ct = Content
 
                                                 local pos =  Ct:find(FX_Name)  
-                                                if pos then   msg(pos)
+                                                if pos then   
                                                     file:seek('set', pos-1)
                                                 else file:seek('end')
                                                 end


### PR DESCRIPTION
- In layout editor, Add shift+Arrow buttons to adjust position by one pixel.
- Add ‘Save all values as default’ button to define plugin’s default values, once set you can double click to revert parameters to their saved default values.
- Disable docking floating windows ( preset morph settings, layout editor, style editor)
- Add alt+right-click on wet dry knob to delta-solo.
- In Band Splitter, Fix soloing and muting when no FX is inside the Splitter
- Add option to put label on parameter’s right side for Selection and Switch type.