### PR TITLE
Release MK Slicer (80icio MOD) v1.10

### DIFF
--- a/Items Editing/MK Slicer (80icio MOD).lua
+++ b/Items Editing/MK Slicer (80icio MOD).lua
@@ -1,11 +1,7 @@
 -- @description MK Slicer (80icio MOD)
 -- @author 80icio
 -- @version 1.10
--- @changelog
---   - Collect hitpoints bug fixed
---
---   - New allpass-based Low Pass and Hi Pass filters for perfect time accuracy.
---   - Fixed 'Control + left-click emulates right click' behaviour on script (thanks cfillion)
+-- @changelog - Collect hitpoints bug fixed
 -- @link Forum Thread https://forum.cockos.com/showthread.php?p=2436358#post2436358
 -- @about
 --   This is a lua script based on MK SLICER 2 by @Cool for quick slicing, quantizing by grid, re-quantizing, triggering or sampling audio.

--- a/Items Editing/MK Slicer (80icio MOD).lua
+++ b/Items Editing/MK Slicer (80icio MOD).lua
@@ -1,7 +1,9 @@
 -- @description MK Slicer (80icio MOD)
 -- @author 80icio
--- @version 1.09
+-- @version 1.10
 -- @changelog
+--   - Collect hitpoints bug fixed
+--
 --   - New allpass-based Low Pass and Hi Pass filters for perfect time accuracy.
 --   - Fixed 'Control + left-click emulates right click' behaviour on script (thanks cfillion)
 -- @link Forum Thread https://forum.cockos.com/showthread.php?p=2436358#post2436358
@@ -5457,7 +5459,7 @@ function Wave:GetSet_MIDITake()
         return item, take
 end
 ------------------------------
---[[
+
 Collect = {}
 function Wave:Collect() -----icio
 local total = 0 + #Collect
@@ -5470,7 +5472,7 @@ local total = 0 + #Collect
     end
   end
   Collect_Stop = true
-end]]--
+end
 -----------------------------------apply Leading PAD-----------icio----------------------
 function lpadapply()
 


### PR DESCRIPTION
- Collect hitpoints bug fixed

- New allpass-based Low Pass and Hi Pass filters for perfect time accuracy.
- Fixed 'Control + left-click emulates right click' behaviour on script (thanks cfillion)