### PR TITLE
Release FX Devices v1.0beta9.6.3

### DIFF
--- a/FX/BryanChi_FX Devices.lua
+++ b/FX/BryanChi_FX Devices.lua
@@ -2,7 +2,6 @@
 -- @author Bryan Chi
 -- @version 1.0beta9.6.3
 -- @changelog
---   FX Devices 9.6.3
 --   - Fix changing Modulator type not working.
 --   - Fix modulated parameters showing incorrect values after reopening script.
 --   - FX Adder : Get rid of ‘!!!VSTi’ for VST instrument FXs.


### PR DESCRIPTION
FX Devices 9.6.3
- Fix changing Modulator type not working.
- Fix modulated parameters showing incorrect values after reopening script.
- FX Adder : Get rid of ‘!!!VSTi’ for VST instrument FXs.
- FX Adder: Remove <SHELL> Entries from waves plugins.
- Pre-FX : Fix misbehaviour when moving FX around when ‘FXD Macros’ is in the first slot of FX Chain.