### PR TITLE
Update One Small Step 0.9.3 > 0.9.4

### DIFF
--- a/MIDI Editor/talagan_OneSmallStep/classes/KeyReleaseActivityManager.lua
+++ b/MIDI Editor/talagan_OneSmallStep/classes/KeyReleaseActivityManager.lua
@@ -9,7 +9,7 @@ local KeyActivityManager   = require "classes/KeyActivityManager";
 KeyReleaseActivityManager = KeyActivityManager:new();
 
 function KeyReleaseActivityManager:inertia()
-  return 0.2;
+  return EngineLib.getSetting("KeyReleaseModeForgetTime");
 end
 
 -- We need to override the default cleanup because we want to keep track of
@@ -62,7 +62,7 @@ function KeyReleaseActivityManager:tryAdvancedCommitForTrack(track, commit_callb
   -- Perform the commit of released keys
   if #candidates > 0 then
     if commit_callback then
-      commit_callback(candidates)
+      commit_callback(candidates, {})
     end
   end
 

--- a/MIDI Editor/talagan_OneSmallStep/talagan_OneSmallStep Helper lib.lua
+++ b/MIDI Editor/talagan_OneSmallStep/talagan_OneSmallStep Helper lib.lua
@@ -15,6 +15,7 @@ jsfx.paramIndex_PedalActivity   = 0
 jsfx.paramIndex_NotesInBuffer   = 1
 jsfx.paramIndex_NoteStart       = 2
 
+
 -- Add the given fx to the given track.
 local function getOrAddInputFx(track, fx)
 
@@ -22,19 +23,23 @@ local function getOrAddInputFx(track, fx)
   local idx = reaper.TrackFX_AddByName(track, fx.name, true, 0);
 
   if idx == -1 or idx == nil then
+    reaper.Undo_BeginBlock();
+
+    local _, tname  = reaper.GetTrackName(track);
     -- Try to add it.
-    idx         = reaper.TrackFX_AddByName(track, fx.name, true, 1);
+    idx             = reaper.TrackFX_AddByName(track, fx.name, true, 1);
 
     if idx == -1 or idx == nil then
-      return -1
+      reaper.Undo_EndBlock("One Small Step : Add companion JSFX on track " .. tname,-1);
+      return -1;
+    else
+      -- It worked, hide it ide it, in case the option to pop up new added FXs is checked
+      reaper.TrackFX_SetOpen(track, idx|0x1000000, false);
+      reaper.Undo_EndBlock("One Small Step : Add companion JSFX on track " .. tname,-1);
     end
-
-    -- Hide it, in case the option to pop up new added FXs is checked
-    reaper.TrackFX_SetOpen(track, idx|0x1000000, false);
   end
 
   -- Use 0x1000000 as flag for input fx chain
-
   return idx|0x1000000
 end
 


### PR DESCRIPTION
Update for One Small Step. Changelog : 

 - [Feature] Added option to allow erasing note endings that do not match cursor when steping back
  - [Feature] Keypress Mode : Added Sustain Inertia to detect held keys when pressing other keys
  - [Feature] Added options to tweak Key Release / Key Press reaction times
  - [Feature] Added option to choose if input notes are selected or not
  - [Feature] Added option to automatically cleanup JSFXs on closing (thanks @stevie !)
  - [Feature] Added an option to prevent notes from being inserted if the sustain pedal modifier key is pressed (this blocks insertion, useful in KP mode when starting an erase operation)
  - [Bug Fix] Project boundaries were not updated if the edited item was the last one and was extended (thanks @daodan !)
  - [Bug Fix] Reduced intensive CPU usage when OSS is runing due to unuseful calls to Undo_Begin/End