### PR TITLE
Update OneSmallStep 0.9.11 > 0.9.12

### DIFF
--- a/MIDI Editor/talagan_OneSmallStep/classes/engine_lib.lua
+++ b/MIDI Editor/talagan_OneSmallStep/classes/engine_lib.lua
@@ -331,7 +331,7 @@ local function handleMarkerOnExit(policy_setting_name, marker_name)
     -- Need to backup the position
     -- Save on master track to be project dependent
     local id, pos     = MK.findMarker(marker_name)
-    local masterTrack = reaper.GetMasterTrack()
+    local masterTrack = reaper.GetMasterTrack(0)
     local str         = "";
 
     if not (id == nil) then
@@ -349,7 +349,7 @@ end
 local function mayRestoreMarkerOnStart(policy_setting_name, marker_name)
   local setting = S.getSetting("PlaybackMarkerPolicyWhenClosed");
   if setting == "Hide/Restore" then
-    local masterTrack = reaper.GetMasterTrack()
+    local masterTrack = reaper.GetMasterTrack(0)
     local succ, str = reaper.GetSetMediaTrackInfo_String(masterTrack, "P_EXT:OneSmallStep:MarkerBackup:" .. marker_name, '', false);
     if succ and str ~= "" then
       MK.setMarkerAtPos(marker_name, tonumber(str))

--- a/MIDI Editor/talagan_OneSmallStep/classes/modules/defines.lua
+++ b/MIDI Editor/talagan_OneSmallStep/classes/modules/defines.lua
@@ -73,6 +73,19 @@ local ActionTriggers = {
   StuffBack         = { action = "Unstuff",      back = true    }
 }
 
+local RepitchModeAffects = {
+  PitchesOnly           = "Pitches only",
+  VelocitiesOnly        = "Velocities only",
+  PitchesAndVelocities  = "Pitches + Velocities"
+}
+
+local MiddleInsertBehavior = {
+  LeaveUntouched        = "Leave Untouched",
+  Cut                   = "Cut note",
+  Extend                = "Extend note",
+  CutAndAdd             = "Cut note and insert new one"
+}
+
 local MacOSModifierKeys = {
   { vkey = 16, name = 'Shift' },
   { vkey = 17, name = 'Cmd' },
@@ -124,6 +137,10 @@ return {
   InputMode                     = InputMode,
   EditMode                      = EditMode,
   IsMacOs                       = IsMacOs,
+
+  RepitchModeAffects            = RepitchModeAffects,
+
+  MiddleInsertBehavior          = MiddleInsertBehavior,
 
   ActionTriggers                = ActionTriggers,
 

--- a/MIDI Editor/talagan_OneSmallStep/classes/modules/notes.lua
+++ b/MIDI Editor/talagan_OneSmallStep/classes/modules/notes.lua
@@ -35,6 +35,27 @@ local function GetNote(take, ni, use_mu)
   }
 end
 
+local function CloneNote(n)
+  local newn = {}
+  for k,v in pairs(n) do
+    newn[k] = v
+  end
+  newn.index = nil
+
+  return newn
+end
+
+-- Commits a note in the currently open MidiUtils transaction.
+-- - The note can be new (without index) and this will add it to the transaction.
+-- - The note can already exist (with an index), and this will just modify it.
+local function MUCommitNote(take, n)
+  if n.index then
+    MU.MIDI_SetNote(take, n.index, n.selected, n.muted, n.startPPQ, n.endPPQ, n.chan, n.pitch, n.vel, n.offvel)
+  else
+    MU.MIDI_InsertNote(take, n.selected, n.muted, n.startPPQ, n.endPPQ, n.chan, n.pitch, n.vel, n.offvel)
+  end
+end
+
 local function SetNewNoteBounds(note, take, startPPQ, endPPQ)
   note.startPPQ = T.PPQRound(startPPQ)
   note.endPPQ   = T.PPQRound(endPPQ)
@@ -65,7 +86,9 @@ end
 
 return {
   GetNote           = GetNote,
+  CloneNote         = CloneNote,
   SetNewNoteBounds  = SetNewNoteBounds,
   CountEvts         = CountEvts,
-  BuildFromManager  = BuildFromManager
+  BuildFromManager  = BuildFromManager,
+  MUCommitNote      = MUCommitNote
 }

--- a/MIDI Editor/talagan_OneSmallStep/classes/modules/settings.lua
+++ b/MIDI Editor/talagan_OneSmallStep/classes/modules/settings.lua
@@ -45,13 +45,12 @@ local SettingDefs = {
   KeyReleaseModeForgetTime                                  = { type = "double",  default = 0.200, min = 0.05, max = 0.4},
 
   RepitchModeAggregationTime                                = { type = "double",  default = 0.05, min = 0,   max = 0.1 },
-  RepitchModeAffects                                        = { type = "string",  default = "Pitches Only", inclusion = { "Pitches only", "Velocities only", "Pitches + Velocities" } },
+  RepitchModeAffects                                        = { type = "string",  default = D.RepitchModeAffects.PitchesOnly, inclusion = { D.RepitchModeAffects.PitchesOnly, D.RepitchModeAffects.VelocitiesOnly, D.RepitchModeAffects.PitchesAndVelocities } },
 
   PedalRepeatEnabled                                        = { type = "bool" ,   default = true },
   PedalRepeatTime                                           = { type = "double",  default = 0.200, min = 0.05, max = 0.5 },
   PedalRepeatFirstHitMultiplier                             = { type = "int",     default = 4, min = 1, max = 10 },
 
-  Snap                                                      = { type = "bool",    default = false },
   SnapNotes                                                 = { type = "bool",    default = true },
   SnapProjectGrid                                           = { type = "bool",    default = true },
   SnapItemGrid                                              = { type = "bool",    default = true },
@@ -66,7 +65,28 @@ local SettingDefs = {
   VelocityLimiterEnabled                                    = { type = "bool",    default = false },
   VelocityLimiterMin                                        = { type = "int",     default = 0,    min = 0, max = 127 },
   VelocityLimiterMax                                        = { type = "int",     default = 127,  min = 0, max = 127 },
-  VelocityLimiterMode                                       = { type = "string",  default = "Linear", inclusion = { "Linear", "Clamp"} }
+  VelocityLimiterMode                                       = { type = "string",  default = "Linear", inclusion = { "Linear", "Clamp"} },
+
+  InsertModeInMiddleOfMatchingNotesBehaviour                = {
+    type = "string",
+    default = D.MiddleInsertBehavior.LeaveUntouched,
+    inclusion = {
+      D.MiddleInsertBehavior.LeaveUntouched,
+      D.MiddleInsertBehavior.Extend,
+      D.MiddleInsertBehavior.Cut,
+      D.MiddleInsertBehavior.CutAndAdd
+    }
+  },
+
+  InsertModeInMiddleOfNonMatchingNotesBehaviour            = {
+    type = "string",
+    default = D.MiddleInsertBehavior.LeaveUntouched,
+    inclusion = {
+      D.MiddleInsertBehavior.LeaveUntouched,
+      D.MiddleInsertBehavior.Extend,
+      D.MiddleInsertBehavior.Cut,
+    }
+  }
 };
 
 

--- a/MIDI Editor/talagan_OneSmallStep/classes/modules/snap.lua
+++ b/MIDI Editor/talagan_OneSmallStep/classes/modules/snap.lua
@@ -103,7 +103,10 @@ local function nextSnap(track, direction, reftime, options)
   local bestJumpTime    = nil
   local maxTime         = 0
 
-  if options.enabled and track then
+  -- If one of these options is on, we need to do a full dig of items
+  local snapItemThings  = options.itemGrid or options.itemBounds or options.noteStart or options.noteEnd
+
+  if snapItemThings and track then
 
     -- Force Item Bounds when we have item grid on, that's usefule outside items
     if options.itemGrid then
@@ -216,11 +219,12 @@ end
 
 local function snapOptions()
   return {
-    enabled       = S.getSetting("Snap"),
-    itemBounds    = S.getSetting("SnapItemBounds"),
+    -- Item related
     noteStart     = S.getSetting("SnapNotes"),
     noteEnd       = S.getSetting("SnapNotes"),
     itemGrid      = S.getSetting("SnapItemGrid"),
+    itemBounds    = S.getSetting("SnapItemBounds"),
+    -- Larger
     projectGrid   = S.getSetting("SnapProjectGrid"),
     projectBounds = true
   }

--- a/MIDI Editor/talagan_OneSmallStep/classes/modules/target.lua
+++ b/MIDI Editor/talagan_OneSmallStep/classes/modules/target.lua
@@ -70,7 +70,7 @@ end
 
 local function TryToGetTakeFromArrangeViewAmongSelectedTracks()
   local cursorPos      = reaper.GetCursorPosition();
-  local trackCount     = reaper.CountSelectedTracks();
+  local trackCount     = reaper.CountSelectedTracks(0);
 
   local candidates  = {};
 
@@ -138,7 +138,7 @@ local function TakeForEdition()
 end
 
 local function TrackForEditionIfNoItemFound()
-  local trackCount     = reaper.CountSelectedTracks();
+  local trackCount     = reaper.CountSelectedTracks(0);
   if trackCount > 0 then
     return reaper.GetSelectedTrack(0, 0);
   end

--- a/MIDI Editor/talagan_OneSmallStep/classes/modules/time.lua
+++ b/MIDI Editor/talagan_OneSmallStep/classes/modules/time.lua
@@ -53,6 +53,13 @@ local function noteEndsInWindowPPQ(note, left, right, strict)
   return a and e
 end
 
+local function noteContainsPPQ(note, ppq, strict)
+  local a = noteStartsBeforePPQ(note, ppq, strict)
+  local e = noteEndsAfterPPQ(note, ppq, strict)
+
+  return a and e
+end
+
 local function PPQRound(ppq)
   return math.floor(ppq + 0.5) -- Compensate floating errors
 end
@@ -218,6 +225,7 @@ return {
   noteEndsBeforePPQ     = noteEndsBeforePPQ,
   noteEndsOnPPQ         = noteEndsOnPPQ,
   noteEndsInWindowPPQ   = noteEndsInWindowPPQ,
+  noteContainsPPQ       = noteContainsPPQ,
 
   TimeRoundBasedOnPPQ   = TimeRoundBasedOnPPQ,
 

--- a/MIDI Editor/talagan_OneSmallStep/classes/operations/generic.lua
+++ b/MIDI Editor/talagan_OneSmallStep/classes/operations/generic.lua
@@ -8,6 +8,10 @@ local T   = require "modules/time"
 local N   = require "modules/notes"
 local MK  = require "modules/markers"
 
+local MU  = require "lib/MIDIUtils"
+
+local USE_MU = true
+
 local function BuildContext(km, track, take)
   local c = {}
 
@@ -72,27 +76,8 @@ end
 
 local function ForwardOperationFinish(c, jumpTime, newMaxQN)
 
-  -- Modify notes
-  for ri = 1, #c.tomod, 1 do
-    local n = c.tomod[ri]
-    reaper.MIDI_SetNote(c.take, n.index, nil, nil, n.startPPQ, n.endPPQ, nil, nil, nil, true )
-  end
+  MU.MIDI_CommitWriteTransaction(c.take)
 
-  -- Delete notes that were shorten too much
-  -- Do this in reverse order to be sure that indices are descending
-  for ri = #c.torem, 1, -1 do
-    local n = c.torem[ri]
-    reaper.MIDI_DeleteNote(c.take, n.index)
-  end
-
-  -- Reinsert moved notes
-  for ri = 1, #c.toadd, 1 do
-    local n = c.toadd[ri]
-    reaper.MIDI_InsertNote(c.take, n.selected, n.muted, n.startPPQ, n.endPPQ, n.chan, n.pitch, n.vel, true )
-  end
-
-  -- Advance and mark dirty
-  reaper.MIDI_Sort(c.take)
   reaper.UpdateItemInProject(c.mediaItem)
 
   -- Grow the midi item if needed
@@ -123,26 +108,9 @@ local function ForwardOperationFinish(c, jumpTime, newMaxQN)
 end
 
 local function BackwardOperationFinish(c, jumpTime)
-  -- Modify notes
-  for ri = 1, #c.tomod, 1 do
-    local n = c.tomod[ri]
-    reaper.MIDI_SetNote(c.take, n.index, nil, nil, n.startPPQ, n.endPPQ, nil, nil, nil, true )
-  end
 
-  -- Delete notes that were shorten too much
-  -- Do this in reverse order to be sure that indices are descending
-  for ri = #c.torem, 1, -1 do
-    reaper.MIDI_DeleteNote(c.take, c.torem[ri].index)
-  end
+  MU.MIDI_CommitWriteTransaction(c.take)
 
-  -- Reinsert moved notes
-  for ri = 1, #c.toadd, 1 do
-    local n = c.toadd[ri]
-    reaper.MIDI_InsertNote(c.take, n.selected, n.muted, n.startPPQ, n.endPPQ, n.chan, n.pitch, n.vel, true )
-  end
-
-  -- Rewind and mark dirty
-  reaper.MIDI_Sort(c.take)
   reaper.UpdateItemInProject(c.mediaItem)
   reaper.MarkTrackItemsDirty(c.track, c.mediaItem)
 
@@ -154,58 +122,14 @@ local function BackwardOperationFinish(c, jumpTime)
   end
 end
 
-
--- This function is used by the write/insert/replace modes
-local function AddAndExtendNotes(c, notes_to_add, notes_to_extend)
-  -- Then add some other notes
-  for _, v in ipairs(notes_to_add) do
-    c.toadd[#c.toadd+1] = N.BuildFromManager(v, c.take, c.cursorPPQ, c.advancePPQ)
-    c.counts.add = c.counts.add + 1
-  end
-
-  -- Then extend notes
-  if #notes_to_extend > 0 then
-    local _, notecnt, _, _ = reaper.MIDI_CountEvts(c.take);
-
-    for _, exnote in pairs(notes_to_extend) do
-
-      -- Search for a note that could be extended (matches all conditions)
-      local ni    = 0
-      local found = false
-
-      while (ni < notecnt) do
-        local n = N.GetNote(c.take, ni)
-
-        -- Extend the note if found
-        if T.noteEndsOnPPQ(n, c.cursorPPQ) and (n.chan == exnote.chan) and (n.pitch == exnote.pitch) then
-
-          c.tomod[#c.tomod + 1] = n
-          N.SetNewNoteBounds(n, c.take, n.startPPQ, c.advancePPQ)
-
-          c.counts.ext = c.counts.ext + 1
-          found = true
-        end
-
-        ni = ni + 1
-      end
-
-      if not found then
-        -- Could not find a note to extend... create one !
-        c.toadd[#c.toadd+1] = N.BuildFromManager(exnote, c.take, c.cursorPPQ, c.advancePPQ)
-        c.counts.add = c.counts.add + 1
-      end
-    end
-  end
-end
-
 local function GenericDelete(c, notes_to_shorten, selectiveErase, shiftMode)
 
-  local _, notecnt, _, _ = reaper.MIDI_CountEvts(c.take);
+  local _, notecnt, _, _  = N.CountEvts(c.take, USE_MU)
   local ni = 0;
   while (ni < notecnt) do
 
     -- Examine each note in item
-    local n = N.GetNote(c.take, ni)
+    local n = N.GetNote(c.take, ni, USE_MU)
 
     local targetable = false
 
@@ -232,9 +156,7 @@ local function GenericDelete(c, notes_to_shorten, selectiveErase, shiftMode)
         if shiftMode then
           -- Move the note back
           N.SetNewNoteBounds(n, c.take, n.startPPQ - c.noteLenPPQ, n.endPPQ - c.noteLenPPQ)
-
-          c.torem[#c.torem+1]   = n -- Remove
-          c.toadd[#c.toadd+1]   = n -- And readd
+          N.MUCommitNote(c.take, n)
 
           c.counts.mv           = c.counts.mv + 1
         end
@@ -247,7 +169,8 @@ local function GenericDelete(c, notes_to_shorten, selectiveErase, shiftMode)
           --     | === |
           --     |     |
           --
-          c.torem[#c.torem+1] = n
+          MU.MIDI_DeleteNote(c.take, n.index)
+
           c.counts.rem        = c.counts.rem + 1
         else
           -- The note should be shortened (removing tail).
@@ -260,9 +183,7 @@ local function GenericDelete(c, notes_to_shorten, selectiveErase, shiftMode)
           --
           local offset = (shiftMode) and (- c.noteLenPPQ) or (0)
           N.SetNewNoteBounds(n, c.take, c.cursorPPQ + offset, n.endPPQ + offset)
-
-          c.torem[#c.torem+1]   = n
-          c.toadd[#c.toadd+1]   = n
+          N.MUCommitNote(c.take, n)
 
           c.counts.sh = c.counts.sh + 1
           c.counts.mv = c.counts.mv + 1
@@ -278,24 +199,23 @@ local function GenericDelete(c, notes_to_shorten, selectiveErase, shiftMode)
           --
           if shiftMode or T.noteEndsOnPPQ(n, c.cursorPPQ) then
             N.SetNewNoteBounds(n, c.take, n.startPPQ, n.endPPQ - c.noteLenPPQ)
+            N.MUCommitNote(c.take, n)
 
-            c.tomod[#c.tomod+1] = n
             c.counts.sh         = c.counts.sh + 1
           else
-            -- Create a hole in the note. Copy note
-            local newn = {}
-            for k,v in pairs(n) do
-              newn[k] = v
-            end
+            -- Create a hole in the note. Clone note
+            local newn = N.CloneNote(n)
 
             -- Shorted remaining note
             N.SetNewNoteBounds(n, c.take, n.startPPQ, c.rewindPPQ);
-            c.tomod[#c.tomod+1] = n
+            N.MUCommitNote(c.take, n)
+
             c.counts.sh         = c.counts.sh + 1
 
             -- Add new note
             N.SetNewNoteBounds(newn, c.take, c.cursorPPQ, newn.endPPQ);
-            c.toadd[#c.toadd+1] = newn
+            N.MUCommitNote(c.take, newn)
+
             c.counts.add        = c.counts.add + 1
           end
 
@@ -308,7 +228,8 @@ local function GenericDelete(c, notes_to_shorten, selectiveErase, shiftMode)
           --     |     |
           --
           N.SetNewNoteBounds(n, c.take, n.startPPQ, c.rewindPPQ)
-          c.tomod[#c.tomod+1] = n
+          N.MUCommitNote(c.take, n)
+
           c.counts.sh         = c.counts.sh + 1
         else
           -- Leave untouched
@@ -323,6 +244,58 @@ local function GenericDelete(c, notes_to_shorten, selectiveErase, shiftMode)
     end
 
     ni = ni + 1;
+  end
+end
+
+
+-- This function is used by the write/insert/replace modes
+local function AddAndExtendNotes(c, notes_to_add, notes_to_extend)
+
+  -- Then add some other notes
+  for _, v in ipairs(notes_to_add) do
+
+    if not v.ignored then
+      local newn = N.BuildFromManager(v, c.take, c.cursorPPQ, c.advancePPQ)
+      N.MUCommitNote(c.take, newn)
+      c.counts.add = c.counts.add + 1
+    end
+  end
+
+  -- Then extend notes
+  if #notes_to_extend > 0 then
+    local _, notecnt, _, _  = N.CountEvts(c.take, USE_MU)
+
+    for _, exnote in pairs(notes_to_extend) do
+      if not exnote.ignored then
+        -- Search for a note that could be extended (matches all conditions)
+        local ni    = 0
+        local found = false
+
+        while (ni < notecnt) do
+          local n = N.GetNote(c.take, ni, USE_MU)
+
+          -- Extend the note if found
+          if T.noteEndsOnPPQ(n, c.cursorPPQ) and (n.chan == exnote.chan) and (n.pitch == exnote.pitch) then
+
+            N.SetNewNoteBounds(n, c.take, n.startPPQ, c.advancePPQ)
+            N.MUCommitNote(c.take, n)
+
+            c.counts.ext = c.counts.ext + 1
+            found = true
+          end
+
+          ni = ni + 1
+        end
+
+        if not found then
+          -- Could not find a note to extend... create one !
+          local newn = N.BuildFromManager(exnote, c.take, c.cursorPPQ, c.advancePPQ)
+          N.MUCommitNote(c.take, newn)
+
+          c.counts.add = c.counts.add + 1
+        end
+      end
+    end
   end
 end
 
@@ -355,12 +328,14 @@ local function OperationSummary(direction, counts)
   return "One Small Step: " .. table.concat(description, ", ")
 end
 
+
 return {
   BuildForwardContext     = BuildForwardContext,
   BuildBackwardContext    = BuildBackwardContext,
   OperationSummary        = OperationSummary,
   ForwardOperationFinish  = ForwardOperationFinish,
   BackwardOperationFinish = BackwardOperationFinish,
-  AddAndExtendNotes       = AddAndExtendNotes,
-  GenericDelete           = GenericDelete
+  GenericDelete           = GenericDelete,
+
+  AddAndExtendNotes       = AddAndExtendNotes
 }

--- a/MIDI Editor/talagan_OneSmallStep/classes/operations/insert.lua
+++ b/MIDI Editor/talagan_OneSmallStep/classes/operations/insert.lua
@@ -7,10 +7,23 @@ local T   = require "modules/time"
 local S   = require "modules/settings"
 local D   = require "modules/defines"
 local N   = require "modules/notes"
-
 local GEN = require "operations/generic"
+local MU  = require "lib/MIDIUtils"
 
-local function Insert(km, track, take, notes_to_add, notes_to_extend, triggered_by_key_event)
+local USE_MU = true
+
+local function NoteMatchesOneOf(note, note_bunch)
+  local matchingNote = nil
+  for _, nn in ipairs(note_bunch) do
+    if nn.pitch == note.pitch then
+      matchingNote = nn
+      break
+    end
+  end
+  return matchingNote
+end
+
+local function Insert(km, track, take, new_notes, held_notes, triggered_by_key_event)
 
   local c         = GEN.BuildForwardContext(km, track, take)
 
@@ -19,32 +32,82 @@ local function Insert(km, track, take, notes_to_add, notes_to_extend, triggered_
   reaper.Undo_BeginBlock();
 
   -- First, move some notes
-  local _, notecnt, _, _ = reaper.MIDI_CountEvts(take)
+  MU.MIDI_InitializeTake(take)
+  MU.MIDI_OpenWriteTransaction(take)
+
+  local _, notecnt, _, _  = N.CountEvts(take, USE_MU)
   local ni = 0
 
   -- Shift notes
   while (ni < notecnt) do
-    local n = N.GetNote(take, ni);
+    local n = N.GetNote(take, ni, USE_MU)
 
     if T.noteStartsAfterPPQ(n, c.cursorPPQ, false) then
-      -- Move the note
+      -- Push the note back
       N.SetNewNoteBounds(n, take, n.startPPQ + c.noteLenPPQ, n.endPPQ + c.noteLenPPQ)
+      N.MUCommitNote(c.take, n)
+
+      c.counts.mv = c.counts.mv + 1
 
       if n.endQN > newMaxQN then
         newMaxQN = n.endQN
       end
+    elseif T.noteContainsPPQ(n, c.cursorPPQ, true) then
+      -- This is a complex case. We may cut, leave untouch, extend from the interior, or cut + add
 
-      -- It should be removed and readded, because the start position changes
-      c.torem[#c.torem + 1] = n
-      c.toadd[#c.toadd + 1] = n
+      -- Does a new/held note matches this note ?
+      local nn        = NoteMatchesOneOf(n, new_notes)
+      local hn        = NoteMatchesOneOf(n, held_notes)
+      local hasMatch  = (nn ~= nil or hn ~= nil)
 
-      c.counts.mv = c.counts.mv + 1
+      local behavior = S.getSetting("InsertModeInMiddleOfNonMatchingNotesBehaviour")
+
+      if hasMatch then
+        -- There's a match
+        behavior = S.getSetting("InsertModeInMiddleOfMatchingNotesBehaviour")
+      end
+
+      if behavior == D.MiddleInsertBehavior.LeaveUntouched then
+      elseif behavior == D.MiddleInsertBehavior.Cut or behavior == D.MiddleInsertBehavior.CutAndAdd then
+        -- First, clone the note
+        local en = N.CloneNote(n)
+
+        -- Keep left part, shorten existing note
+        N.SetNewNoteBounds(n, take, n.startPPQ, c.cursorPPQ)
+        N.MUCommitNote(c.take, n)
+        c.counts.sh = c.counts.sh + 1
+
+        -- Create right part
+        N.SetNewNoteBounds(en, take, c.advancePPQ, en.endPPQ + c.noteLenPPQ)
+        N.MUCommitNote(c.take, en)
+        c.counts.add = c.counts.add + 1
+
+        if behavior == D.MiddleInsertBehavior.CutAndAdd then
+          -- Fill the new gap
+          local an = N.BuildFromManager(nn or hn, take, c.cursorPPQ, c.advancePPQ)
+          N.MUCommitNote(take, an)
+          c.counts.add = c.counts.add + 1
+        end
+      elseif behavior == D.MiddleInsertBehavior.Extend then
+        N.SetNewNoteBounds(n, take, n.startPPQ, n.endPPQ + c.noteLenPPQ)
+        N.MUCommitNote(take, n)
+        c.counts.ext = c.counts.ext + 1
+        if n.endQN > newMaxQN then
+          newMaxQN = n.endQN
+        end
+      end
+
+      if hasMatch then
+        -- This event has been treated, it will not add a new note in the add loop
+        if nn then nn.ignored = true end
+        if hn then hn.ignored = true end
+      end
     end
 
     ni = ni + 1
   end
 
-  GEN.AddAndExtendNotes(c, notes_to_add, notes_to_extend)
+  GEN.AddAndExtendNotes(c, new_notes, held_notes)
   GEN.ForwardOperationFinish(c, c.advanceTime, newMaxQN)
 
   reaper.Undo_EndBlock(GEN.OperationSummary(1, c.counts), -1)
@@ -69,6 +132,9 @@ local function InsertBack(km, track, take, notes_to_shorten, triggered_by_key_ev
   end
 
   reaper.Undo_BeginBlock();
+
+  MU.MIDI_InitializeTake(take)
+  MU.MIDI_OpenWriteTransaction(take)
 
   GEN.GenericDelete(c,notes_to_shorten, false, true)
   GEN.BackwardOperationFinish(c, c.rewindTime)

--- a/MIDI Editor/talagan_OneSmallStep/classes/operations/write.lua
+++ b/MIDI Editor/talagan_OneSmallStep/classes/operations/write.lua
@@ -7,8 +7,10 @@ local T   = require "modules/time"
 local S   = require "modules/settings"
 local D   = require "modules/defines"
 local AT  = require "modules/action_triggers"
-
+local MU  = require "lib/MIDIUtils"
 local GEN = require "operations/generic"
+
+local USE_MU = true
 
 -- Commits the currently held notes into the take
 local function Write(km, track, take, notes_to_add, notes_to_extend, triggered_by_key_event)
@@ -18,6 +20,8 @@ local function Write(km, track, take, notes_to_add, notes_to_extend, triggered_b
 
   reaper.Undo_BeginBlock();
 
+  MU.MIDI_InitializeTake(take)
+  MU.MIDI_OpenWriteTransaction(take)
   GEN.AddAndExtendNotes(c, notes_to_add, notes_to_extend)
   GEN.ForwardOperationFinish(c, c.advanceTime, newMaxQN)
 


### PR DESCRIPTION
Update for OneSmallStep. Changelog : 

  - [Feature] Added some options to tweak the insert mode behavior when inserting in the middle of existing notes (thanks @samlletas !)
  - [Bug Fix] Repitch mode would not work for fresh installs (thanks @samlletas !)
  - [Bug Fix] Navigation mode snap would not work for fresh installs
  - [Rework] Ported all operations to the 'MIDIUtils' library by @sockmonkey72 (thanks Jeremy !!)