### PR TITLE
Track icon selector Categories sorting

### DIFF
--- a/Tracks/reapertips_Track icon selector.lua
+++ b/Tracks/reapertips_Track icon selector.lua
@@ -1,9 +1,8 @@
 -- @description Track icon selector
 -- @author Reapertips & Sexan
--- @version 1.05
+-- @version 1.06
 -- @changelog
---  Add root level images to "root" table (needed to make sorting work)
---  Sort categories alphabetically
+--  Account master track in selections
 -- @provides
 --   reatips_Track icon selector/*.png
 -- @screenshot
@@ -556,8 +555,8 @@ local function main()
     end
 
     TRACKS = {}
-    for i = 1, r.CountSelectedTracks(nil) do
-        TRACKS[#TRACKS + 1] = r.GetSelectedTrack(nil, i - 1)
+    for i = 1, r.CountSelectedTracks2(nil, true) do
+        TRACKS[#TRACKS + 1] = r.GetSelectedTrack2(nil, i - 1, true)
     end
     imgui.PushStyleColor(ctx, imgui.Col_WindowBg, COLORS["win_bg"])
     imgui.PushStyleColor(ctx, imgui.Col_TitleBgActive, COLORS["win_bg"])

--- a/Tracks/reapertips_Track icon selector.lua
+++ b/Tracks/reapertips_Track icon selector.lua
@@ -1,8 +1,9 @@
 -- @description Track icon selector
 -- @author Reapertips & Sexan
--- @version 1.06
+-- @version 1.07
 -- @changelog
---  Account master track in selections
+--  Allow keyboard navigation (up,down,left,right,enter)
+--  Clicking on any icon sets keyboard focus there
 -- @provides
 --   reatips_Track icon selector/*.png
 -- @screenshot
@@ -101,7 +102,7 @@ local icon_size = 32
 
 r.set_action_options(1)
 
-local ctx = imgui.CreateContext('Track icon selector')
+local ctx = imgui.CreateContext('Track icon selector', imgui.ConfigFlags_NavEnableKeyboard)
 local WND_W, WND_H = 500, 500
 local FLT_MIN, FLT_MAX = imgui.NumericLimits_Float()
 
@@ -328,9 +329,8 @@ local function PngSelector(button_size)
     local buttons_count = #FILTERED_PNG
     local window_visible_x2 = ({ imgui.GetWindowPos(ctx) })[1] +
         ({ imgui.GetWindowContentRegionMax(ctx) })[1]
-    imgui.PushStyleColor(ctx, imgui.Col_Button, COLORS["win_bg"])
-
-    if imgui.BeginChild(ctx, "filtered_pngs_list", 0, 0) then
+    imgui.PushStyleColor(ctx, imgui.Col_Button, COLORS["win_bg"])    
+    if imgui.BeginChild(ctx, "filtered_pngs_list", 0, 0) then        
         for n = 0, #FILTERED_PNG - 1 do
             local image = FILTERED_PNG[n + 1].name
             local stripped_name = FILTERED_PNG[n + 1].short_name
@@ -341,6 +341,7 @@ local function PngSelector(button_size)
             end
 
             if imgui.ImageButton(ctx, "##png_select", FILTERED_PNG[n + 1].img_obj, button_size, button_size, 0, 0, 1, 1) then
+                imgui.SetKeyboardFocusHere( ctx ,-1)
                 if #TRACKS > 0 then
                     r.Undo_BeginBlock2(nil)
                     for i = 1, #TRACKS do


### PR DESCRIPTION
Table.sort was not working since main table was mix of root level images and directories (nested table). This commit adds root level images to "root" directory (nested table) which then allows table.sort to work

EDIT: Added one small fix to master track selection (GetSelectedTrack2) and added EnableKeyboardNavigation Flag

EDIT2: Ignore/dont merge 1.07 (keyboard navigation), sorry for inconvenience.