### PR TITLE
Update MaCCLane v0.2.1 > v0.2.2

### DIFF
--- a/MIDI Editor/talagan_MaCCLane.lua
+++ b/MIDI Editor/talagan_MaCCLane.lua
@@ -1,16 +1,17 @@
 --[[
 @description MaCCLane : Tabs for the MIDI Editor
-@version 0.2.1
+@version 0.2.2
 @author Ben 'Talagan' Babut
 @license MIT
 @donation https://www.paypal.com/donate/?business=3YEZMY9D6U8NC&no_recurring=1&currency_code=EUR
 @links
   Forum Thread : https://forum.cockos.com/showthread.php?t=298707
 @changelog
-  - [Feature] Tab duplication
-  - [Feature] Quick key modifier operation : Duplicate (with ctrl/cmd)
-  - [Feature] Quick key modifier operation : Delete (with shift)
-  - [Feature] Tab multi export / multi import
+  - [UX] Changed delete modifier to alt (windows) or option (macos) (thanks, Seventh Sam)
+  - [UX] Reduce flickering under windows
+  - [UX] Always give back focus to the ME after tab execution
+  - [Bug Fix] Time window size was not working if time position module was not enabled (thanks, Seventh Sam)
+  - [Bug Fix] Copy/Paste in global scope would crash MaCCLane (thanks, Seventh Sam)
 @provides
   [main=main] .
   [nomain] talagan_MaCCLane/classes/**/*.lua

--- a/MIDI Editor/talagan_MaCCLane/classes/tab_popup_menu.lua
+++ b/MIDI Editor/talagan_MaCCLane/classes/tab_popup_menu.lua
@@ -149,7 +149,7 @@ TabPopupMenu.process = function()
                 -- Try to mimic owner from src owner
                 local owner = nil
                 if srctab.owner_type == Tab.Types.GLOBAL then
-                    owner = GlobalScopeRepo.intance()
+                    owner = GlobalScopeRepo.instance()
                 elseif srctab.owner_type == Tab.Types.TRACK then
                     owner = mec.track
                 elseif srctab.owner_tyep == Tab.Types.ITEM then

--- a/MIDI Editor/talagan_MaCCLane/modules/modifiers.lua
+++ b/MIDI Editor/talagan_MaCCLane/modules/modifiers.lua
@@ -23,8 +23,13 @@ local function WinControlMacCmdIsDown()
     return (reaper.JS_Mouse_GetState(1<<2) ~= 0)
 end
 
+local function WinAltMacOptionIsDown()
+    return (reaper.JS_Mouse_GetState(1<<4) ~= 0)
+end
+
 
 return {
     ShiftIsDown             = ShiftIsDown,
-    WinControlMacCmdIsDown  = WinControlMacCmdIsDown
+    WinControlMacCmdIsDown  = WinControlMacCmdIsDown,
+    WinAltMacOptionIsDown   = WinAltMacOptionIsDown
 }

--- a/MIDI Editor/talagan_MaCCLane/modules/tab_state.lua
+++ b/MIDI Editor/talagan_MaCCLane/modules/tab_state.lua
@@ -658,10 +658,11 @@ local function ApplyTimeline(tab)
     local tparams   = tab.params.time_window
     local tparams_s = tab.state.time_window
 
-    local mode    = tparams.positioning.mode
+    local pmode    = tparams.positioning.mode
+    local smode    = tparams.sizing.mode
 
     -- Skip if bypass
-    if (mode == 'bypass' and mode == 'bypass') then return end
+    if (pmode == 'bypass' and smode == 'bypass') then return end
 
     local start_time, end_time  = TIMELINE.GetBounds(mec.me)
     local duration              = end_time - start_time
@@ -669,7 +670,6 @@ local function ApplyTimeline(tab)
     local ref_offset            = start_time or 0
     local anchoring             = tparams.positioning.anchoring
 
-    local pmode = tparams.positioning.mode
     if pmode == 'custom' or pmode == 'record' then
         local position = tparams.positioning.position
         if pmode == 'record' then
@@ -684,10 +684,11 @@ local function ApplyTimeline(tab)
         if anchoring == 'right'  then ref_offset = start_time + duration        end
     end
 
-    local smode = tparams.positioning.mode
     if smode == 'custom' or smode == 'record' then
         local size = tparams.sizing.size
-        if smode == 'record' then size = tparams_s.sizing.size end
+        if smode == 'record' then
+            size = tparams_s.sizing.size
+        end
 
         duration = reaper.parse_timestr_len(size, ref_offset, -1)
     end


### PR DESCRIPTION
Bug fix update for MaCCLane : 

  - [UX] Changed delete modifier to alt (windows) or option (macos) (thanks, Seventh Sam)
  - [UX] Reduce flickering under windows
  - [UX] Always give back focus to the ME after tab execution
  - [Bug Fix] Time window size was not working if time position module was not enabled (thanks, Seventh Sam)
  - [Bug Fix] Copy/Paste in global scope would crash MaCCLane (thanks, Seventh Sam)