### PR TITLE
Update MaCCLane v0.2.2 > v0.2.3

### DIFF
--- a/MIDI Editor/talagan_MaCCLane.lua
+++ b/MIDI Editor/talagan_MaCCLane.lua
@@ -1,17 +1,17 @@
 --[[
 @description MaCCLane : Tabs for the MIDI Editor
-@version 0.2.2
+@version 0.2.3
 @author Ben 'Talagan' Babut
 @license MIT
 @donation https://www.paypal.com/donate/?business=3YEZMY9D6U8NC&no_recurring=1&currency_code=EUR
 @links
   Forum Thread : https://forum.cockos.com/showthread.php?t=298707
 @changelog
-  - [UX] Changed delete modifier to alt (windows) or option (macos) (thanks, Seventh Sam)
-  - [UX] Reduce flickering under windows
-  - [UX] Always give back focus to the ME after tab execution
-  - [Bug Fix] Time window size was not working if time position module was not enabled (thanks, Seventh Sam)
-  - [Bug Fix] Copy/Paste in global scope would crash MaCCLane (thanks, Seventh Sam)
+  - [Feature] Added "Quick-Fill" buttons (Bypass, Record, Snapshot)
+  - [Feature] Added Read buttons for time pos/window
+  - [UX] Still improving flickering under windows (double buffering)
+  - [Bug Fix] ME's piano roll child window was not correctly focused after tab execution
+  - [Bug Fix] Differentiation new tabs / old tabs was broken in editor
 @provides
   [main=main] .
   [nomain] talagan_MaCCLane/classes/**/*.lua

--- a/MIDI Editor/talagan_MaCCLane/classes/tab_editor.lua
+++ b/MIDI Editor/talagan_MaCCLane/classes/tab_editor.lua
@@ -94,12 +94,29 @@ end
 local function PopRecordStyleSelectable(ctx)
     ImGui.PopStyleColor(ctx, 1)
 end
-
+local function PushRecordStyleButton(ctx)
+    ImGui.PushStyleColor(ctx, ImGui.Col_Text, 0xFF0000FF);
+    ImGui.PushStyleColor(ctx, ImGui.Col_Button, 0xFF9999FF)
+    ImGui.PushStyleColor(ctx, ImGui.Col_ButtonHovered, 0xFF6969FF )
+    ImGui.PushStyleColor(ctx, ImGui.Col_ButtonActive, 0xFF4949FF)
+end
+local function PopRecordStyleButton(ctx)
+    ImGui.PopStyleColor(ctx, 4)
+end
 local function PushBypassStyle(ctx)
     ImGui.PushStyleColor(ctx, ImGui.Col_Text, 0xFFFFFF90)
 end
 local function PopBypassStyle(ctx)
     ImGui.PopStyleColor(ctx, 1)
+end
+local function PushBypassStyleButton(ctx)
+    ImGui.PushStyleColor(ctx, ImGui.Col_Button, 0x808080C0)
+    ImGui.PushStyleColor(ctx, ImGui.Col_ButtonHovered, 0x505050C0 )
+    ImGui.PushStyleColor(ctx, ImGui.Col_ButtonActive, 0x404040C0 )
+    ImGui.PushStyleColor(ctx, ImGui.Col_Text, 0xFFFFFFC0)
+end
+local function PopBypassStyleButton(ctx)
+    ImGui.PopStyleColor(ctx, 4)
 end
 
 local function MoveCursorY(ctx, off)
@@ -1219,6 +1236,11 @@ function TabEditor:gfxTimeLineSection()
             local respos = reaper.parse_timestr_pos(params.position, -1)
             TT(ctx, "Enter a time position using Reaper's format.\n\z
                      This may be expressed:\n\n   - in measures :    M.B.fraction\n   - as a time :      [hh:mm]:ss\n\nCurrently resolved as :\n\n   " .. respos .. " seconds" )
+
+            ImGui.SameLine(ctx)
+            ReadButton(ctx, '##R', function()
+                TabState.ReadTimeWindowPositioning(tab, false)
+            end)
         end
     end
     ImGui.PopID(ctx)
@@ -1255,6 +1277,11 @@ function TabEditor:gfxTimeLineSection()
             local respos = reaper.parse_timestr_len(params.size, offset, -1)
             TT(ctx, "Enter a duration using Reaper's format.\n\z
             This may be expressed:\n\n   - in measures :    M.B.fraction\n   - as a time :      [hh:mm]:ss\n\nCurrently resolved as :\n\n   " .. respos .. " seconds, using offset : " .. offset .. " seconds" )
+
+            ImGui.SameLine(ctx)
+            ReadButton(ctx, '##R', function()
+                TabState.ReadTimeWindowSizing(tab, false)
+            end)
         end
     end
     ImGui.PopID(ctx)
@@ -1547,6 +1574,32 @@ function TabEditor:gfx()
             open = false -- Get rid of it, we won't redraw, so it will be garbage collected
         end
         PopGreenStyle(ctx)
+
+        ImGui.SameLine(ctx)
+        ImGui.Dummy(ctx, 30, 1)
+        ImGui.SameLine(ctx)
+
+        PushBypassStyleButton(ctx)
+        if ImGui.Button(ctx, "Bypass") then
+            TabState.SetFullBypass(tab)
+        end
+        PopBypassStyleButton(ctx)
+
+        TT(ctx, "Set all modules to Bypass")
+        ImGui.SameLine(ctx)
+        PushRecordStyleButton(ctx)
+        if ImGui.Button(ctx, "Record") then
+            TabState.SetFullRecord(tab)
+        end
+        PopRecordStyleButton(ctx)
+        TT(ctx, "Set all modules to Record")
+        ImGui.SameLine(ctx)
+        PushCyanStyle(ctx)
+        if ImGui.Button(ctx, "Snapshot") then
+            TabState.SetFullCustom(tab)
+        end
+        PopCyanStyle(ctx)
+        TT(ctx, "Set all modules to Custom, pinning the MIDI Editor's current state")
 
         ImGui.SameLine(ctx)
 

--- a/MIDI Editor/talagan_MaCCLane/modules/tab_state.lua
+++ b/MIDI Editor/talagan_MaCCLane/modules/tab_state.lua
@@ -363,6 +363,67 @@ local function SetFullRecord(tab)
     p.cc_lanes.mode                     = 'record'
 end
 
+local function SetFullBypass(tab)
+    local p = tab.params
+
+    p.force_record_flag                 = 0
+
+    p.docking.mode                      = 'bypass'
+    p.docking.if_docked.mode            = 'bypass'
+    p.docking.if_windowed.mode          = 'bypass'
+
+    p.time_window.positioning.mode      = 'bypass'
+    p.time_window.sizing.mode           = 'bypass'
+
+    p.grid.mode                         = 'bypass'
+    p.coloring.mode                     = 'bypass'
+
+    p.midi_chans.current                = 'bypass'
+    p.midi_chans.mode                   = 'bypass'
+
+    p.piano_roll.mode                   = 'bypass'
+
+    p.cc_lanes.mode                     = 'bypass'
+end
+
+local function SetFullCustom(tab)
+    local p = tab.params
+
+    p.force_record_flag                 = 0
+
+    p.docking.mode                      = 'custom'
+    p.docking.if_docked.mode            = 'custom'
+    p.docking.if_windowed.mode          = 'custom'
+
+    p.time_window.positioning.mode      = 'custom'
+    p.time_window.sizing.mode           = 'custom'
+
+    p.grid.mode                         = 'custom'
+    p.coloring.mode                     = 'custom'
+
+    p.midi_chans.current                = 'custom'
+    p.midi_chans.mode                   = 'custom'
+
+    p.piano_roll.mode                   = 'custom'
+
+    p.cc_lanes.mode                     = 'custom'
+
+    local vellanes = ReadVellanes(tab)
+    PatchVellaneEntries(tab.params.cc_lanes.entries, vellanes.entries, 'replace')
+
+    ReadDockingMode(tab, false)
+    ReadTimeWindowPositioning(tab, false)
+    ReadTimeWindowSizing(tab, false)
+    ReadDockHeight(tab,false)
+    ReadWindowBounds(tab,false)
+    ReadCurrentPianoRollHighNote(tab, false)
+    ReadCurrentPianoRollLowNote(tab, false)
+    ReadCurrentMidiChan(tab, false)
+    ReadMidiChans(tab, false)
+    ReadGrid(tab, false)
+    ReadColoring(tab, false)
+end
+
 ----------------------------
 
 -- State saving
@@ -784,6 +845,8 @@ return {
     ReadTimeWindowSizing            = ReadTimeWindowSizing,
 
     SetFullRecord                   = SetFullRecord,
+    SetFullBypass                   = SetFullBypass,
+    SetFullCustom                   = SetFullCustom,
 
     SnapShotAll                     = SnapShotAll,
     SnapShotGrid                    = SnapShotGrid,


### PR DESCRIPTION
Fast pace fix/enhance cycle with forum feedback, update to 0.2.3 with following changelog : 

  - [Feature] Added "Quick-Fill" buttons (Bypass, Record, Snapshot)
  - [Feature] Added Read buttons for time pos/window
  - [UX] Still improving flickering under windows (double buffering)
  - [Bug Fix] ME's piano roll child window was not correctly focused after tab execution
  - [Bug Fix] Differentiation new tabs / old tabs was broken in editor