### PR TITLE
Update cfillion_Lua profiler.lua

### DIFF
--- a/Development/cfillion_Lua profiler.lua
+++ b/Development/cfillion_Lua profiler.lua
@@ -1072,7 +1072,7 @@ local function tableView(ctx)
         if not ImGui.TreeNodeEx(ctx, line.key, line.name, tree_node_flags) then
           i = i + line.children
         end
-        tooltip_text = string.format('%s (%d children)',
+        tooltip_text = string.format('%s (%s children)',
           line.name, formatNumber(line.children))
       else
         ImGui.TreeNodeEx(ctx, line.key, line.name, tree_node_leaf_flags)


### PR DESCRIPTION
formatNumber returns a string and string.format is expecting a number. Lua handles this fine when the number is below 1000 but when formatNumber adds a comma to the number string for numbers over 1,000 it causes an error. Changing %d to %s fixes this.