### PR TITLE
Update Reannotate v0.4.0 > v0.4.1

### DIFF
--- a/Development/talagan_EmojImGui/actions/talagan_EmojImGui Demo.lua
+++ b/Development/talagan_EmojImGui/actions/talagan_EmojImGui Demo.lua
@@ -67,7 +67,6 @@ local function loop()
 
         if not picker and ImGui.IsWindowHovered(ctx) and ImGui.IsMouseClicked(ctx, ImGui.MouseButton_Left) then
             picker = EmojImGui.Picker:new()
-            --EmojImGui.Asset.CharInfo("TweMoji", "1F3F4-E0067-E0062-E0077-E006C-E0073-E007F")
         end
 
         if picker and not picker.open then

--- a/Various/talagan_Reannotate.lua
+++ b/Various/talagan_Reannotate.lua
@@ -1,6 +1,6 @@
 --[[
 @description Reannotate - Annotation tool for REAPER
-@version 0.4.0
+@version 0.4.1
 @author Ben 'Talagan' Babut
 @donation https://www.paypal.com/donate/?business=3YEZMY9D6U8NC&no_recurring=1&currency_code=EUR
 @license MIT
@@ -10,11 +10,8 @@
   Forum Thread https://forum.cockos.com/showthread.php?t=304147
 @metapackage
 @changelog
-  - [Feature] Introducing stickers using EmojImGui
-  - [Enhance] Clamped top/bottom elements will not show colored border at the clamping place
-  - [Bug Fix] If launched from a button, any pressed key would close Reannotate (Thanks Smandrap !)
-  - [Bug Fix] Filtering is now case insensitive
-  - [Bug Fix] Reannotate was not DPI aware under windows (Thanks X-Raym !)
+  - [Bug Fix] Sticker edit does not save the sticker in library (thanks, Smandrap !)
+  - [Bug Fix] Notes are not saved if only checking checkboxes
 @provides
   [nomain] talagan_Reannotate/ext/**/*
   [nomain] talagan_Reannotate/classes/**/*

--- a/Various/talagan_Reannotate/widgets/quick_preview_overlay.lua
+++ b/Various/talagan_Reannotate/widgets/quick_preview_overlay.lua
@@ -614,6 +614,7 @@ function QuickPreviewOverlay:drawTooltip()
                 tttext          = before .. interaction.replacement_string .. after
 
                 thing_to_tooltip.notes:setSlotText(slot_to_tooltip, tttext)
+                thing_to_tooltip.notes:commit()
             end
 
             -- Border. Tooltip is shown when edited or hoevered

--- a/Various/talagan_Reannotate/widgets/sticker_picker.lua
+++ b/Various/talagan_Reannotate/widgets/sticker_picker.lua
@@ -236,8 +236,8 @@ function StickerPicker:draw()
       if res and not res:isEmpty() then
         if self.sticker_editor.new_record then
           self.sticker_library[#self.sticker_library+1] = res
-          self:commit()
         end
+        self:commit()
       end
     end
 


### PR DESCRIPTION
Minor "Bug fix" update for Reannotate : 

  - [Bug Fix] Sticker edit does not save the sticker in library (thanks, Smandrap !)
  - [Bug Fix] Notes are not saved if only checking checkboxes