### PR TITLE
Update Reannotate v0.4.2 > v0.4.3

### DIFF
--- a/Various/talagan_Reannotate.lua
+++ b/Various/talagan_Reannotate.lua
@@ -1,6 +1,6 @@
 --[[
 @description Reannotate - Annotation tool for REAPER
-@version 0.4.2
+@version 0.4.3
 @author Ben 'Talagan' Babut
 @donation https://www.paypal.com/donate/?business=3YEZMY9D6U8NC&no_recurring=1&currency_code=EUR
 @license MIT
@@ -10,7 +10,12 @@
   Forum Thread https://forum.cockos.com/showthread.php?t=304147
 @metapackage
 @changelog
-  - [Feature] Can now use stickers without a text
+  - [Feature] The markdown stylesheet is now customizable
+  - [Feature] UI Font size is now customizable
+  - [Feature] Note editor's width is now remembered
+  - [Bug Fix] Tooltips with vertical scrollbars could affect the layout of other tooltips shown immediately after
+  - [Rework] Moved project notes to the transport zone instead of the time ruler (will be used for regions / markers ?)
+  - [Rework] Optimizations
 @provides
   [nomain] talagan_Reannotate/ext/**/*
   [nomain] talagan_Reannotate/classes/**/*

--- a/Various/talagan_Reannotate/classes/app_context.lua
+++ b/Various/talagan_Reannotate/classes/app_context.lua
@@ -6,9 +6,8 @@
 local LaunchContext         = require "classes/launch_context"
 local ArrangeViewWatcher    = require "classes/arrange_view_watcher"
 local ImGui                 = require "ext/imgui"
-local Notes                 = require "classes/notes"
-
 local reaper_ext            = require "modules/reaper_ext"
+local D                     = require "modules/defines"
 
 local AppContext = {}
 AppContext.__index = AppContext
@@ -65,6 +64,7 @@ function AppContext:findMainToolbarHwnd(main_hwnd, time_ruler_hwnd, tcp_hwnd)
     local _, tcp_l, tcp_t,  tcp_r,  tcp_b   = reaper.JS_Window_GetRect(tcp_hwnd)
     local _, l = reaper.JS_Window_ListAllChild(main_hwnd)
     for token in string.gmatch(l, "[^,]+") do
+---@diagnostic disable-next-line: param-type-mismatch
       local subhwnd = reaper.JS_Window_HandleFromAddress(token)
       if subhwnd then
         local _, a_l, a_t, a_r, a_b = reaper.JS_Window_GetRect(subhwnd)
@@ -88,6 +88,8 @@ function AppContext:_initialize()
   self.mv                         = { hwnd=reaper.GetMainHwnd() }
   -- Arrange view
   self.av                         = { hwnd=reaper.JS_Window_FindChildByID(self.mv.hwnd, 1000) }
+
+  self.transport                  = { hwnd=reaper.JS_Window_FindChild(reaper.GetMainHwnd(), "Transport", true) }
   -- TCP view
   self.tcp                        = { hwnd=reaper.JS_Window_FindEx(reaper.GetMainHwnd(), reaper.GetMainHwnd(), "REAPERTCPDisplay", "") }
   -- Time Ruler
@@ -122,7 +124,7 @@ function AppContext:_initialize()
   ImGui.Attach(self.imgui_ctx, self.arial_font_italic)
 
   self.enabled_category_filters = {}
-  for i=1, Notes.MAX_SLOTS do
+  for i=1, D.MAX_SLOTS do
     self.enabled_category_filters[i] = true
   end
 
@@ -210,6 +212,7 @@ function AppContext:updateWindowLayouts()
   self:retrieveCoordinates(self.main_toolbar)
   self:retrieveCoordinates(self.time_ruler)
   self:retrieveCoordinates(self.mcp_window)
+  self:retrieveCoordinates(self.transport)
 
   self.av.pinned_height = self:retrievePinnedTcpHeight()
 

--- a/Various/talagan_Reannotate/classes/color.lua
+++ b/Various/talagan_Reannotate/classes/color.lua
@@ -162,6 +162,14 @@ function Color:new(r_or_string_or_rgb_int,g,b,a)
     return instance
 end
 
+function Color:new_from_iargb(argb)
+  return Color:new( (argb & 0x00FF0000) >> 16, (argb & 0x0000FF00) >> 8, (argb & 0x000000FF), (argb & 0xFF000000) >> 24)
+end
+
+function Color:new_from_irgba(rgba)
+  return Color:new((rgba & 0xFF000000) >> 24, (rgba & 0x00FF0000) >> 16, (rgba & 0x0000FF00) >> 8, (rgba & 0x000000FF))
+end
+
 function Color:validateComponent(name, presence)
   local val = self[name]
 
@@ -220,6 +228,14 @@ function Color:setHsv(h,s,l)
     self.r, self.g, self.b = math.floor(r * 255 + 0.5), math.floor(g * 255 + 0.5), math.floor(b * 255 + 0.5)
 end
 
+function Color:css_rgb()
+  return string.format("#%02X%02X%02X", self.r, self.g, self.b)
+end
+
+function Color:css_argb()
+  return string.format("#%%02X02X%02X%02X", self.a, self.r, self.g, self.b)
+end
+
 function Color:to_irgb()
   return (self.r << 16) | (self.g << 8) | (self.b << 0)
 end
@@ -231,7 +247,6 @@ end
 function Color:to_irgba()
   return (self:to_irgb() << 8) | ((self.a or 255) << 0)
 end
-
 
 function Color.irgba(str)
   return Color.parse(str):to_irgba()

--- a/Various/talagan_Reannotate/classes/mem_cache.lua
+++ b/Various/talagan_Reannotate/classes/mem_cache.lua
@@ -1,0 +1,96 @@
+-- @noindex
+-- @author Ben 'Talagan' Babut
+-- @license MIT
+-- @description This file is part of Reannotate
+
+local Notes = require 'classes/notes'
+
+local MemCache = {}
+MemCache.__index = MemCache
+
+function MemCache:new()
+  local instance = {}
+  setmetatable(instance, self)
+  instance:_initialize()
+  return instance
+end
+
+function MemCache:_initialize()
+  self._repo = {}
+
+  MemCache.__singleton = self
+end
+
+function MemCache.GetObjectGUID(object)
+  local guid = ''
+  if reaper.ValidatePtr(object, "MediaTrack*") then
+    local tguid = reaper.GetTrackGUID(object)
+    guid = tguid
+  elseif reaper.ValidatePtr(object,"MediaItem*") then
+    local _, tguid = reaper.GetSetMediaItemInfo_String(object, "GUID", "", false)
+    guid = tguid
+  elseif reaper.ValidatePtr(object, "TrackEnvelope*") then
+    local _, tguid = reaper.GetSetEnvelopeInfo_String(object, "GUID", "", false)
+    guid = tguid
+  elseif reaper.ValidatePtr(object, "ReaProject*") then
+    local _, tguid = reaper.GetSetProjectInfo_String(object, "PROJECT_NAME", "", false)
+    guid = tguid
+  else
+    error("Unhandled type for object")
+  end
+  return guid
+end
+
+function MemCache:getObjectCache(object)
+
+  local guid = MemCache.GetObjectGUID(object)
+
+  if not self._repo[guid] then
+    -- Build object cache
+
+    local name = ''
+    local type = ''
+    if reaper.ValidatePtr(object, "MediaTrack*") then
+      local _, tname = reaper.GetTrackName(object)
+      name = tname
+      type = 'track'
+    elseif reaper.ValidatePtr(object,"MediaItem*") then
+      local take = reaper.GetActiveTake(object)
+      if take then
+        name = reaper.GetTakeName(take)
+      end
+      type = 'item'
+    elseif reaper.ValidatePtr(object, "TrackEnvelope*") then
+      local _, ename = reaper.GetEnvelopeName(object)
+      name = ename
+      type = 'env'
+    elseif reaper.ValidatePtr(object, "ReaProject*") then
+      name = "Project"
+      type = 'project'
+    else
+      error("Unhandled type for object")
+    end
+
+    -- Cache miss, pull info from object
+    self._repo[guid] = {
+      guid    = guid,
+      object  = object,
+      name    = name,
+      type    = type,
+      -- Notes cache
+      notes   = Notes:new(object)
+    }
+  end
+
+  return self._repo[guid]
+end
+
+function MemCache.instance()
+  if not MemCache.__singleton then
+    MemCache.__singleton = MemCache:new()
+  end
+
+  return MemCache.__singleton
+end
+
+return MemCache

--- a/Various/talagan_Reannotate/modules/debug.lua
+++ b/Various/talagan_Reannotate/modules/debug.lua
@@ -56,9 +56,18 @@ local function LaunchProfilerIfNeeded()
         -- So, force preload DSP functions before "attach to world"
 
         -- Require here all files containing things to be profiled.
-        local ImGui = require "ext/imgui"
-        local QuickPreviewOverlay = require "widgets/quick_preview_overlay"
-        local EmojImGui           = require "emojimgui"
+        local EmojImGui             = require "emojimgui"
+
+        local ImGui                 = require "ext/imgui"
+
+        local QuickPreviewOverlay   = require "widgets/quick_preview_overlay"
+        local OverlayCanvas         = require "widgets/overlay_canvas"
+
+        local Notes                 = require "classes/notes"
+        local Sticker               = require "classes/sticker"
+        local Color                 = require "classes/color"
+        local AppContext            = require "classes/app_context"
+        local ArrangeViewWatcher    = require "classes/arrange_view_watcher"
 
         local profiler = dofile(reaper.GetResourcePath() .. '/Scripts/ReaTeam Scripts/Development/cfillion_Lua profiler.lua')
         reaper.defer = profiler.defer

--- a/Various/talagan_Reannotate/modules/defines.lua
+++ b/Various/talagan_Reannotate/modules/defines.lua
@@ -1,0 +1,207 @@
+-- @noindex
+-- @author Ben 'Talagan' Babut
+-- @license MIT
+-- @description This file is part of Reannotate
+
+local S       = require "modules/settings"
+local JSON    = require "ext/json"
+
+local Defines = {}
+
+Defines.TT_DEFAULT_W = 300
+Defines.TT_DEFAULT_H = 100
+Defines.MAX_SLOTS    = 8 -- Slot 0 is counted
+
+local OS                            = reaper.GetOS()
+local is_windows                    = OS:match('Win')
+local is_macos                      = OS:match('OSX') or OS:match('macOS')
+local is_linux                      = OS:match('Other')
+
+Defines.OS              = OS
+Defines.is_windows      = is_windows
+Defines.is_macos        = is_macos
+Defines.is_linux        = is_linux
+
+Defines.POST_IT_COLORS = {
+    0xFFFFFF, -- WHITE      Slot 0
+    0x40acff, -- BLUE
+    0x753ffc, -- VIOLET
+    0xff40e5, -- PINK
+    0xffe240, -- YELLOW
+    0x3cf048, -- GREEN
+    0xff9640, -- ORANGE
+    0xff4040, -- RED        Slot 7
+}
+
+Defines.slot_labels = nil
+Defines.slot_labels_dirty = nil
+
+function Defines.deepCopy(orig)
+    local orig_type = type(orig)
+    local copy
+    if orig_type == 'table' then
+        copy = {}
+        for orig_key, orig_value in next, orig, nil do
+            copy[Defines.deepCopy(orig_key)] = Defines.deepCopy(orig_value)
+        end
+        setmetatable(copy, Defines.deepCopy(getmetatable(orig)))
+    else -- number, string, boolean, etc
+        copy = orig
+    end
+    return copy
+end
+
+function Defines.deepCompare(tbl1, tbl2)
+	if tbl1 == tbl2 then
+		return true
+	elseif type(tbl1) == "table" and type(tbl2) == "table" then
+		for key1, value1 in pairs(tbl1) do
+			local value2 = tbl2[key1]
+
+			if value2 == nil then
+				-- avoid the type call for missing keys in tbl2 by directly comparing with nil
+				return false
+			elseif value1 ~= value2 then
+				if type(value1) == "table" and type(value2) == "table" then
+					if not Defines.deepCompare(value1, value2) then
+						return false
+					end
+				else
+					return false
+				end
+			end
+		end
+
+		-- check for missing keys in tbl1
+		for key2, _ in pairs(tbl2) do
+			if tbl1[key2] == nil then
+				return false
+			end
+		end
+
+		return true
+	end
+
+	return false
+end
+
+function Defines.ActiveProject()
+    local p, _ = reaper.EnumProjects(-1)
+    return p
+end
+
+function Defines.ActiveProjectMasterTrack()
+    return reaper.GetMasterTrack(Defines.ActiveProject())
+end
+
+function Defines.defaultTooltipSize()
+    return Defines.TT_DEFAULT_W, Defines.TT_DEFAULT_H
+end
+
+function Defines.SlotColor(slot)
+    return Defines.POST_IT_COLORS[slot+1]
+end
+
+----- Project Labels
+
+function Defines.RetrieveProjectSlotLabels()
+    local _, str = reaper.GetSetMediaTrackInfo_String(Defines.ActiveProjectMasterTrack(), "P_EXT:Reannotate_ProjectSlotLabels", "", false)
+    local slot_labels = {}
+    if str == "" or str == nil then
+    else
+        slot_labels = JSON.decode(str)
+    end
+
+    -- Ensure labels have names by defaulting to global setting
+    for i = 0, Defines.MAX_SLOTS -1 do
+        slot_labels[i+1] = slot_labels[i+1] or S.getSetting("SlotLabel_" .. i)
+    end
+
+    Defines.slot_labels = slot_labels
+end
+
+function Defines.CommitProjectSlotLabels()
+    if not Defines.slot_labels_dirty  then return end
+    if not Defines.slot_labels        then Defines.RetrieveProjectSlotLabels() end
+
+    local str = JSON.encode(Defines.slot_labels)
+    reaper.GetSetMediaTrackInfo_String(Defines.ActiveProjectMasterTrack(), "P_EXT:Reannotate_ProjectSlotLabels", str, true)
+    Defines.slot_labels_dirty = false
+end
+
+function Defines.SlotLabel(slot)
+    if not Defines.slot_labels then Defines.RetrieveProjectSlotLabels() end
+    return Defines.slot_labels[slot+1]
+end
+
+function Defines.SetSlotLabel(slot, label)
+    if not Defines.slot_labels then Defines.RetrieveProjectSlotLabels() end
+    Defines.slot_labels[slot+1] = label
+    Defines.slot_labels_dirty = true
+    Defines.CommitProjectSlotLabels()
+end
+
+------- Project Markdown
+
+-- Not edited directly because we want preview / save features.
+function Defines.RetrieveProjectMarkdownStyle()
+    local _, str            = reaper.GetSetMediaTrackInfo_String(Defines.ActiveProjectMasterTrack(), "P_EXT:Reannotate_ProjectMarkdownStyle", "", false)
+
+    local markdown_style = nil
+    local fallback       = false
+
+    if str == "" or str == nil then
+        fallback = true
+    else
+        pcall(function()
+            markdown_style = JSON.decode(str)
+        end)
+
+        if not markdown_style then
+            fallback = true
+        end
+    end
+
+    if fallback then
+        -- Use new project markdown style
+        markdown_style = Defines.deepCopy(S.getSetting("NewProjectMarkdown"))
+        -- Commit it in project
+        Defines.CommitProjectMarkdownStyle(markdown_style)
+    end
+
+    -- TODO : Normalize markdown_style after checkout for backward comp
+
+    return markdown_style
+end
+
+function Defines.CommitProjectMarkdownStyle(markdown_style)
+    -- TODO : Normalize markdown_style before commit for backward comp
+
+    local str = JSON.encode(markdown_style)
+
+    reaper.GetSetMediaTrackInfo_String(Defines.ActiveProjectMasterTrack(),"P_EXT:Reannotate_ProjectMarkdownStyle", str, true)
+end
+
+function Defines.RetrieveProjectStickerSize()
+    local _, str =  reaper.GetSetMediaTrackInfo_String(Defines.ActiveProjectMasterTrack(), "P_EXT:Reannotate_ProjectStickerSize", "", false)
+    local fallback = false
+    local size = nil
+    if str == "" or str == nil then
+        fallback = true
+    else
+        size = tonumber(str)
+    end
+
+    if fallback then
+        size = S.getSetting("NewProjectStickerSize")
+        Defines.CommitProjectStickerSize(size)
+    end
+
+    return size
+end
+
+function Defines.CommitProjectStickerSize(size)
+    reaper.GetSetMediaTrackInfo_String(Defines.ActiveProjectMasterTrack(),"P_EXT:Reannotate_ProjectStickerSize", "" .. size, true)
+end
+
+return Defines

--- a/Various/talagan_Reannotate/modules/settings.lua
+++ b/Various/talagan_Reannotate/modules/settings.lua
@@ -3,8 +3,29 @@
 -- @license MIT
 -- @description This file is part of Reannotate
 
-local os                            = reaper.GetOS()
-local is_windows                    = os:match('Win')
+local JSON = require "ext/json"
+
+local DefaultMarkdownStyle = {
+    default     = { font_family = "Arial", base_color = "#CCCCCC", bold_color = "white", autopad = 5 --[[font_size = 13, ]] },
+
+    h1          = { font_family = "Arial", font_size = 23, padding_left = 0,        padding_top = 0, padding_bottom = 0,      line_spacing = 0, base_color = "#288efa", bold_color = "#288efa" },
+    h2          = { font_family = "Arial", font_size = 21, padding_left = 5,        padding_top = 0, padding_bottom = 0,      line_spacing = 0, base_color = "#4da3ff", bold_color = "#4da3ff" },
+    h3          = { font_family = "Arial", font_size = 19, padding_left = 10,       padding_top = 0, padding_bottom = 0,      line_spacing = 0, base_color = "#65acf7", bold_color = "#65acf7" },
+    h4          = { font_family = "Arial", font_size = 17, padding_left = 15,       padding_top = 0, padding_bottom = 0,      line_spacing = 0, base_color = "#85c0ff", bold_color = "#85c0ff" },
+    h5          = { font_family = "Arial", font_size = 15, padding_left = 20,       padding_top = 0, padding_bottom = 0,      line_spacing = 0, base_color = "#9ecdff", bold_color = "#9ecdff" },
+
+    paragraph   = { font_family = "Arial", font_size = 13, padding_left = 30,       padding_top = 2, padding_bottom = 2,      line_spacing = 0, padding_in_blockquote = 6 },
+    list        = { font_family = "Arial", font_size = 13, padding_left = 40,       padding_top = 2, padding_bottom = 2,      line_spacing = 0, padding_indent = 5 },
+
+    table       = { font_family = "Arial", font_size = 13, padding_left = 30,       padding_top = 2, padding_bottom = 2,      line_spacing = 0 },
+
+    code        = { font_family = "monospace", font_size = 13, padding_left = 30,   padding_top = 2, padding_bottom = 2,      line_spacing = 4, padding_in_blockquote = 6 },
+    blockquote  = { font_family = "Arial", font_size = 13, padding_left = 0,        padding_top = 2, padding_bottom = 2,      line_spacing = 2, padding_indent = 10 },
+
+    link        = { base_color = "orange", bold_color = "tomato"},
+
+    separator   = { padding_top = 3, padding_bottom = 7 }
+}
 
 local SettingDefs = {
   UseDebugger               = { type = "bool",    default = false },
@@ -18,6 +39,11 @@ local SettingDefs = {
   SlotLabel_5               = { type = "string", default = "Completed"},
   SlotLabel_6               = { type = "string", default = "Warnings"},
   SlotLabel_7               = { type = "string", default = "Problems"},
+
+  -- Styling
+  UIFontSize                = { type = "int",  default = 12 },
+  NewProjectMarkdown        = { type = "json", default = DefaultMarkdownStyle },
+  NewProjectStickerSize     = { type = "int",  default = 12 }
 };
 
 local function unsafestr(str)
@@ -42,6 +68,12 @@ local function serializedStringToValue(str, spec)
       val = tonumber(val);
     elseif spec.type == 'string' then
       -- No conversion needed
+    elseif spec.type == 'json' then
+      local succ, _ ,_ = pcall(function()
+        val = JSON.decode(val)
+      end)
+      -- Fallback on the default if decoding explodes
+      if not succ then val = spec.default end
     end
   end
 
@@ -59,6 +91,8 @@ local function valueToSerializedString(val, spec)
   elseif spec.type == "string" then
     -- No conversion needed
     str = val
+  elseif spec.type == 'json' then
+    str = JSON.encode(val)
   end
   return str
 end

--- a/Various/talagan_Reannotate/widgets/note_editor.lua
+++ b/Various/talagan_Reannotate/widgets/note_editor.lua
@@ -5,13 +5,16 @@
 
 local ImGui         = require "ext/imgui"
 local AppContext    = require "classes/app_context"
-local Notes         = require "classes/notes"
 local Color         = require "classes/color"
 local StickerPicker = require "widgets/sticker_picker"
 local Sticker       = require "classes/sticker"
+local D             = require "modules/defines"
+local S             = require "modules/settings"
 
-local NoteEditor = {}
-NoteEditor.__index = NoteEditor
+local NoteEditor    = {}
+NoteEditor.__index  = NoteEditor
+
+NoteEditor.known_width = nil
 
 function NoteEditor:new()
   local instance = {}
@@ -21,18 +24,19 @@ function NoteEditor:new()
 end
 
 function NoteEditor:_initialize()
-  self.draw_count  = 0
-  self.rand        = math.random()
-  self.open        = true
-  self.sticker_base_size = Sticker.DEFAULT_SIZE
+  self.draw_count         = 0
+  self.tab_draw_count     = 0
+  self.rand               = math.random()
+  self.open               = true
 end
 
 function NoteEditor:setPosition(x,y)
   self.x, self.y = x, y
+  self.should_set_position = true
 end
 
-function NoteEditor:setSize(w,h)
-  self.w, self.h = w, h
+function NoteEditor:setHeight(h)
+  self.wanted_height = h
 end
 
 function NoteEditor:setEditedThing(thing)
@@ -48,22 +52,28 @@ function NoteEditor:GrabFocus()
 end
 
 function NoteEditor:title()
-  local t = "Editing annotations for "
+  if not self.hwnd then
+    return "Editing annotations for "
+  end
 
-  if self.edited_thing.type == "track" then
+  local t     = "Editing annotations for "
+  local type  = self.edited_thing.cache.type
+
+  if type == "track" then
     t = t .. "Track"
-  elseif self.edited_thing.type == "env" then
+  elseif type == "env" then
     t = t .. "Envelope"
-  elseif self.edited_thing.type == "item" then
+  elseif type == "item" then
     t = t .. "Item"
-  elseif self.edited_thing.type == "project" then
+  elseif type == "project" then
     t = t .. "Project"
   else
     error("Unimplemented")
   end
 
-  t = t .. " "
-  t = t .. self.edited_thing.name
+  t = t .. " '"
+  t = t .. self.edited_thing.cache.name
+  t = t .. "'"
 
   return t
 end
@@ -80,15 +90,20 @@ function NoteEditor:onSlotCommit()
   end
 end
 
+function NoteEditor:stickerSize()
+  return D.RetrieveProjectStickerSize()
+end
+
 function NoteEditor:renderStickerZone(ctx, stickers, should_go_to_line)
   local num_on_line     = 0
   local xc, yc          = ImGui.GetCursorScreenPos(ctx)
   local last_vspacing   = nil
   local clicked         = nil
-  local color           = Color:new(Notes.SlotColor(self.edited_slot)):to_irgba()
+  local color           = Color:new(D.SlotColor(self.edited_slot)):to_irgba()
+  local sticker_size    = self:stickerSize()
 
   for _, sticker in ipairs(stickers) do
-    local metrics           = sticker:PreRender(ctx, self.sticker_base_size)
+    local metrics           = sticker:PreRender(ctx, sticker_size)
     local estimated_width   = metrics.width
     local estimated_spacing = 4
 
@@ -149,20 +164,32 @@ function NoteEditor:draw()
   local ctx         = app_ctx.imgui_ctx
   local cursor_func = app_ctx.cursor_func
 
-  local x = self.x or 100
-  local y = self.y or 100
-  local w = self.w or 300
-  local h = self.h or 200
+  -- Default size
+  ImGui.SetNextWindowSize(ctx, 600, 300, ImGui.Cond_FirstUseEver)
 
-  local minw = math.max(w, 300)
-  local minh = math.max(h, 200)
+  -- Forced position, when clicking on a thing to edit
+  if self.should_set_position then
+    local x = self.x or 100
+    local y = self.y or 100
+    self.should_set_position = false
+    ImGui.SetNextWindowPos(ctx, x, y, ImGui.Cond_Always)
+  end
 
-  ImGui.SetNextWindowSize(ctx, w, h, ImGui.Cond_Appearing)
-  ImGui.SetNextWindowPos(ctx, x, y, ImGui.Cond_Appearing )
+  -- Forced height, to align editor's height to tooltip
+  if self.wanted_height and self.w then
+    ImGui.SetNextWindowSize(ctx, self.w, self.wanted_height, ImGui.Cond_Always)
+    self.wanted_height = nil
+  end
 
-  -- Don't save the settings
-  local b, is_open = ImGui.Begin(ctx, self:title() .. "##edit_notes_" .. self.rand, true, ImGui.WindowFlags_TopMost | ImGui.WindowFlags_NoSavedSettings)
+  ImGui.PushFont(ctx, app_ctx.arial_font, S.getSetting("UIFontSize"))
+
+  -- Be sure to use ###, because we want to save the window's settings, especially for the width. The title may change
+  -- Especially at the beginning of the life of the window because we it to be fixed at start, to retrieve the hwnd
+  local b, is_open = ImGui.Begin(ctx, self:title() .. "###reannotate_note_editor", true, ImGui.WindowFlags_TopMost)
   if b then
+    -- Store the known width, to know where to place the editor.
+    -- The width is controlled by the user and stored in the saved settings.
+    NoteEditor.known_width = ImGui.GetWindowWidth(ctx)
 
     ImGui.PushID(ctx, "note_editor_" .. self.rand)
 
@@ -178,33 +205,35 @@ function NoteEditor:draw()
     else
       if not self.hwnd then
         self.hwnd = reaper.JS_Window_Find(self:title(), true)
-        if not self.hwnd then
-          error("CANNOT RETRIEVE HWND FOR NOTE EDITOR")
+        if self.hwnd then
+         -- reaper.ShowConsoleMsg("GOT HWND")
         end
       end
     end
 
     if ImGui.IsWindowAppearing(ctx) then
-      self.draw_count = 0
+      self.draw_count     = 0
+      self.tab_draw_count = 0
     end
 
-    if self.draw_count == 1 then
+    if self.tab_draw_count == 1 then
       ImGui.Function_SetValue(app_ctx.cursor_func, "WANTED_CURSOR", string.len(entry))
     end
 
-    local sel_col = Color:new(Notes.SlotColor(self.edited_slot))
+    local sel_col = Color:new(D.SlotColor(self.edited_slot))
     ImGui.PushStyleColor(ctx, ImGui.Col_TabSelected, sel_col:to_irgba())
 
     if ImGui.BeginTabBar(ctx, "Test##note_editor_tab", ImGui.TabBarFlags_NoCloseWithMiddleMouseButton | ImGui.TabBarFlags_NoTabListScrollingButtons) then
 
       local selection_has_changed = (self.last_selected_tab ~= self.edited_slot)
 
-      for i=0, Notes.MAX_SLOTS-1 do
-        local slot    = (i==Notes.MAX_SLOTS - 1) and (0) or (i+1) -- Put SWS/Reaper at the end
+      for i=0, D.MAX_SLOTS-1 do
+        local slot    = (i==D.MAX_SLOTS - 1) and (0) or (i+1) -- Put SWS/Reaper at the end
 
-        if slot == 0 and self.edited_thing.type == "env" then
+        if slot == 0 and self.edited_thing.cache.type == "env" then
+          -- There's no envelope support for SWS/reaper natively
         else
-          local col     = Color:new(Notes.SlotColor(slot))
+          local col     = Color:new(D.SlotColor(slot))
           local h, s, v = col:hsv()
 
           local tab_col = Color:new(0)
@@ -221,7 +250,7 @@ function NoteEditor:draw()
             flags = flags | ImGui.TabItemFlags_SetSelected
           end
 
-          local e_vis, e_sel = ImGui.BeginTabItem(ctx, Notes.SlotLabel(slot), false, flags)
+          local e_vis, e_sel = ImGui.BeginTabItem(ctx, D.SlotLabel(slot), false, flags)
 
           if e_vis then
             -- The tab api is awfull and needs to track things to avoid race conditions
@@ -229,7 +258,7 @@ function NoteEditor:draw()
               if slot ~= self.edited_slot then
                 self.edited_slot = slot
                 self.grab_focus = true
-                self.draw_count = 0
+                self.tab_draw_count = 0
                 self.sticker_picker = nil
                 self:onSlotEditChange()
               end
@@ -257,7 +286,7 @@ function NoteEditor:draw()
 
     local slot_stickers = self.edited_thing.notes:slotStickers(self.edited_slot)
     if #slot_stickers > 0 then
-      slot_stickers = Sticker.UnpackCollection(slot_stickers, self.edited_thing, self.edited_slot)
+      slot_stickers = slot_stickers
 
       local sticker_clicked = self:renderStickerZone(ctx, slot_stickers, false)
       if sticker_clicked and ImGui.IsKeyDown(ctx, ImGui.Mod_Ctrl) then
@@ -268,8 +297,8 @@ function NoteEditor:draw()
             stickers[#stickers+1] = s
           end
         end
-        local stickers_packed = Sticker.PackCollection(Sticker.NormalizeCollection(stickers, false))
-        self.edited_thing.notes:setSlotStickers(self.edited_slot, stickers_packed)
+        local stickers_patched = Sticker.NormalizeCollection(stickers, false)
+        self.edited_thing.notes:setSlotStickers(self.edited_slot, stickers_patched)
         self.edited_thing.notes:commit()
       end
     end
@@ -299,13 +328,9 @@ function NoteEditor:draw()
     end
 
     if b and is_open then
+      -- Commit on every text change
       self.edited_thing.notes:setSlotText(self.edited_slot, entry)
       self.edited_thing.notes:commit()
-
-      local alternate_entry = self.edited_thing.mcp_entry or self.edited_thing.tcp_entry
-      if alternate_entry then
-        alternate_entry.notes:pull()
-      end
       self:onSlotCommit()
     end
 
@@ -324,15 +349,13 @@ function NoteEditor:draw()
         self.sticker_picker.open = false
 
         -- Get stickers from slot
-        local stickers_packed = self.edited_thing.notes:slotStickers(self.edited_slot)
-        -- Unpack stickers
-        local stickers        = Sticker.UnpackCollection(stickers_packed, self.edited_thing, self.edited_slot)
+        local stickers = self.edited_thing.notes:slotStickers(self.edited_slot)
         -- Add sticker to slot
         stickers[#stickers+1] = picked_sticker
-        -- Repack
-        stickers_packed = Sticker.PackCollection(Sticker.NormalizeCollection(stickers, false))
+        -- Normalize (sort/uniq/etc)
+        stickers = Sticker.NormalizeCollection(stickers, false)
 
-        self.edited_thing.notes:setSlotStickers(self.edited_slot, stickers_packed)
+        self.edited_thing.notes:setSlotStickers(self.edited_slot, stickers)
         self.edited_thing.notes:commit()
       end
     end
@@ -344,8 +367,10 @@ function NoteEditor:draw()
     ImGui.PopID(ctx)
     ImGui.End(ctx)
 
-    self.draw_count = self.draw_count + 1
+    self.draw_count     = self.draw_count + 1
+    self.tab_draw_count = self.tab_draw_count + 1
   end
+  ImGui.PopFont(ctx)
 
   self.open = is_open
 end

--- a/Various/talagan_Reannotate/widgets/settings_editor.lua
+++ b/Various/talagan_Reannotate/widgets/settings_editor.lua
@@ -5,39 +5,436 @@
 
 local ImGui         = require "ext/imgui"
 local AppContext    = require "classes/app_context"
+local Color         = require "classes/color"
+local Sticker       = require "classes/sticker"
 local Notes         = require "classes/notes"
 local S             = require "modules/settings"
+local D             = require "modules/defines"
+
+local ImGuiMd       = require "reaimgui_markdown"
 
 local SettingsEditor = {}
 SettingsEditor.__index = SettingsEditor
 
 function SettingsEditor:new()
-  local instance = {}
-  setmetatable(instance, self)
-  instance:_initialize()
-  return instance
+    local instance = {}
+    setmetatable(instance, self)
+    instance:_initialize()
+    return instance
 end
 
 function SettingsEditor:_initialize()
-    self.draw_count = 0
-    self.open = true
+    self.draw_count             = 0
+    self.open                   = true
+
+    self.new_project_markdown_style   = self:retrieveNewProjectMarkdownStyle()
+    self.cur_project_markdown_style   = self:retrieveCurProjectMarkdownStyle()
+
+    self.new_project_sticker_size     = S.getSetting("NewProjectStickerSize")
+    self.cur_project_sticker_size     = D.RetrieveProjectStickerSize()
+
+    self.mdwidget_new_proj  = ImGuiMd:new(AppContext:instance().imgui_ctx, "markdown_widget_new_proj", { wrap = true, autopad = true, skip_last_whitespace = true }, self.new_project_markdown_style )
+    self.mdwidget_cur_proj  = ImGuiMd:new(AppContext:instance().imgui_ctx, "markdown_widget_cur_proj", { wrap = true, autopad = true, skip_last_whitespace = true }, self.cur_project_markdown_style )
+end
+
+function SettingsEditor:retrieveNewProjectMarkdownStyle()
+    return D.deepCopy(S.getSetting("NewProjectMarkdown"))
+end
+
+function SettingsEditor:retrieveCurProjectMarkdownStyle()
+    return D.deepCopy(D.RetrieveProjectMarkdownStyle())
 end
 
 function SettingsEditor:setPosition(pos_x, pos_y)
     self.pos = { x = pos_x, y = pos_y}
 end
 
+function SettingsEditor:categoryNamesTable()
+    local app_ctx   = AppContext:instance()
+    local ctx       = app_ctx.imgui_ctx
+
+    if ImGui.BeginTable(ctx, "aaaa##table", 3, 0) then
+        ImGui.TableSetupColumn(ctx, "")
+        ImGui.TableSetupColumn(ctx, "New Project")
+        ImGui.TableSetupColumn(ctx, "Current Project")
+        ImGui.TableHeadersRow(ctx)
+        for i=0, D.MAX_SLOTS-1 do
+            local slot = (i==D.MAX_SLOTS - 1) and (0) or (i+1)
+            ImGui.TableNextRow(ctx)
+            ImGui.TableNextColumn(ctx)
+
+            ---@diagnostic disable-next-line: undefined-field
+            ImGui.PushItemFlag(ctx, ImGui.ItemFlags_NoTabStop, true)
+            ImGui.ColorEdit4(ctx, "##col_slot_" .. i, (D.SlotColor(slot) << 8) | 0xFF, ImGui.ColorEditFlags_NoPicker | ImGui.ColorEditFlags_NoDragDrop | ImGui.ColorEditFlags_NoInputs | ImGui.ColorEditFlags_NoBorder | ImGui.ColorEditFlags_NoTooltip)
+            ---@diagnostic disable-next-line: undefined-field
+            ImGui.PopItemFlag(ctx)
+
+            --ImGui.Text(ctx,"y1")
+            ImGui.TableNextColumn(ctx)
+            ImGui.SetNextItemWidth(ctx, 150)
+            if slot ~= 0 then
+                local lab   = S.getSetting("SlotLabel_" .. slot)
+                local b, v  = ImGui.InputText(ctx, "##new_proj_edit_slot_" .. i, lab)
+                if b then
+                    S.setSetting("SlotLabel_" .. slot, v)
+                end
+            else
+                ImGui.Text(ctx, " " .. D.SlotLabel(slot))
+            end
+            ImGui.TableNextColumn(ctx)
+            ImGui.SetNextItemWidth(ctx, 150)
+            if slot ~= 0 then
+                local b, v = ImGui.InputText(ctx, "##cur_proj_edit_slot_" .. i, D.SlotLabel(slot))
+                if b then
+                    D.SetSlotLabel(slot, v)
+                end
+            else
+                ImGui.Text(ctx, " " .. D.SlotLabel(slot))
+            end
+        end
+        ImGui.TableNextRow(ctx)
+        ImGui.TableNextColumn(ctx)
+        ImGui.TableNextColumn(ctx)
+        if ImGui.Button(ctx, "Reset to defaults##reset_global_labels_to_defaults_button") then
+            for i = 0, D.MAX_SLOTS-1 do
+                S.resetSetting("SlotLabel_"..i)
+            end
+        end
+        ImGui.TableNextColumn(ctx)
+        if ImGui.Button(ctx, "Reset to defaults##reset_project_labels_to_defaults_button") then
+            for i = 0, D.MAX_SLOTS-1 do
+                D.SetSlotLabel(i, S.getSettingSpec("SlotLabel_"..i).default )
+            end
+        end
+
+        ImGui.EndTable(ctx)
+    end
+end
+
+function SettingsEditor:markdownTableHeaders()
+    local app_ctx   = AppContext:instance()
+    local ctx       = app_ctx.imgui_ctx
+
+    ImGui.TableSetupColumn(ctx, "Style",            ImGui.TableColumnFlags_WidthFixed, 70)
+    ImGui.TableSetupColumn(ctx, "Normal weight",    ImGui.TableColumnFlags_WidthFixed, 16)
+    ImGui.TableSetupColumn(ctx, "Bold Weight",      ImGui.TableColumnFlags_WidthFixed, 16)
+    ImGui.TableSetupColumn(ctx, "Size",             ImGui.TableColumnFlags_WidthFixed, 50)
+    ImGui.TableSetupColumn(ctx, "Pad Top",          ImGui.TableColumnFlags_WidthFixed, 50)
+    ImGui.TableSetupColumn(ctx, "Pad Bot",          ImGui.TableColumnFlags_WidthFixed, 50)
+
+    ImGui.TableNextRow(ctx, ImGui.TableRowFlags_Headers)
+    ImGui.TableNextColumn(ctx); ImGui.TableHeader(ctx, "Style");    ImGui.SetItemTooltip(ctx, "Style Name")
+    ImGui.TableNextColumn(ctx); ImGui.TableHeader(ctx, " N");        ImGui.SetItemTooltip(ctx, "Normal Weight Color")
+    ImGui.TableNextColumn(ctx); ImGui.TableHeader(ctx, " B");        ImGui.SetItemTooltip(ctx, "Bold Color")
+    ImGui.TableNextColumn(ctx); ImGui.TableHeader(ctx, "Size");     ImGui.SetItemTooltip(ctx, "Font Size")
+    ImGui.TableNextColumn(ctx); ImGui.TableHeader(ctx, "Pad T");    ImGui.SetItemTooltip(ctx, "Padding Top")
+    ImGui.TableNextColumn(ctx); ImGui.TableHeader(ctx, "Pad B");    ImGui.SetItemTooltip(ctx, "Padding Bottom")
+end
+
+function SettingsEditor:markdownRow(widget, style, entry_name)
+    local app_ctx   = AppContext:instance()
+    local ctx       = app_ctx.imgui_ctx
+    local b, v      = false, ''
+
+    local sub_style = style[entry_name]
+
+    ImGui.PushID(ctx, "style_" .. entry_name)
+    ImGui.TableNextRow(ctx)
+
+    ImGui.TableNextColumn(ctx)
+    ImGui.AlignTextToFramePadding(ctx)
+    ImGui.Text(ctx, entry_name)
+
+    local function _update_style()
+        widget:setStyle(style)
+        widget:setText("") -- Force recalculation of the ast
+    end
+
+    ImGui.TableNextColumn(ctx)
+    if sub_style.base_color then
+        b, v = ImGui.ColorEdit3(ctx, "##base_color", Color:new(sub_style.base_color):to_iargb(), ImGui.ColorEditFlags_NoLabel | ImGui.ColorEditFlags_NoSidePreview | ImGui.ColorEditFlags_NoInputs)
+        if b then
+            sub_style.base_color = Color:new_from_iargb(v):css_rgb()
+            _update_style()
+        end
+    end
+
+    ImGui.TableNextColumn(ctx)
+    if sub_style.bold_color then
+        b, v = ImGui.ColorEdit3(ctx, "##bold_color", Color:new(sub_style.bold_color):to_iargb(), ImGui.ColorEditFlags_NoLabel | ImGui.ColorEditFlags_NoSidePreview | ImGui.ColorEditFlags_NoInputs)
+        if b then
+            sub_style.bold_color = Color:new_from_iargb(v):css_rgb()
+            _update_style()
+        end
+    end
+
+    ImGui.TableNextColumn(ctx)
+    ImGui.SetNextItemWidth(ctx, 50)
+    if sub_style.font_size then
+        b, v = ImGui.SliderInt(ctx, "##font_size", sub_style.font_size, 8, 30)
+        if b then
+            sub_style.font_size = v
+            _update_style()
+        end
+    end
+
+    ImGui.TableNextColumn(ctx)
+    ImGui.SetNextItemWidth(ctx, 50)
+    if sub_style.padding_top then
+        b, v = ImGui.SliderInt(ctx, "##pad_top", sub_style.padding_top, 0, 15)
+        if b then
+            sub_style.padding_top = v
+            _update_style()
+        end
+    end
+
+    ImGui.TableNextColumn(ctx)
+    ImGui.SetNextItemWidth(ctx, 50)
+
+    if sub_style.padding_bottom then
+        b, v = ImGui.SliderInt(ctx, "##pad_bot", sub_style.padding_bottom, 0, 15)
+        if b then
+            sub_style.padding_bottom = v
+            _update_style()
+        end
+    end
+
+    ImGui.PopID(ctx)
+end
+
+function SettingsEditor:stickersStyleRow(sticker_size_get_callback, sticker_size_update_callback)
+    local app_ctx   = AppContext:instance()
+    local ctx       = app_ctx.imgui_ctx
+    local b, v      = false, ''
+
+    ImGui.PushID(ctx, "style_sticker")
+    ImGui.TableNextRow(ctx)
+    ImGui.TableNextRow(ctx)
+
+    ImGui.TableNextColumn(ctx)
+    ImGui.AlignTextToFramePadding(ctx)
+    ImGui.Text(ctx, "stickers")
+
+    ImGui.TableNextColumn(ctx) -- Color normal
+    ImGui.TableNextColumn(ctx) -- Color bold
+    ImGui.TableNextColumn(ctx) -- Font Size
+    ImGui.SetNextItemWidth(ctx, 50)
+
+    b, v = ImGui.SliderInt(ctx, "##font_size", sticker_size_get_callback(), 8, 20)
+    if b then
+        sticker_size_update_callback(v)
+    end
+
+    ImGui.TableNextColumn(ctx) -- padding top
+    ImGui.TableNextColumn(ctx) -- padding bottom
+    ImGui.PopID(ctx)
+end
+
+function SettingsEditor:markdownStyles(widget, style_container)
+    self:markdownRow(widget, style_container, "default")
+    self:markdownRow(widget, style_container, "link")
+    self:markdownRow(widget, style_container, "paragraph")
+    self:markdownRow(widget, style_container, "h1")
+    self:markdownRow(widget, style_container, "h2")
+    self:markdownRow(widget, style_container, "h3")
+    self:markdownRow(widget, style_container, "h4")
+    self:markdownRow(widget, style_container, "h5")
+    self:markdownRow(widget, style_container, "list")
+    self:markdownRow(widget, style_container, "table")
+    self:markdownRow(widget, style_container, "blockquote")
+    self:markdownRow(widget, style_container, "code")
+end
+
+local WIDGET_WIDTH  = 300
+local PREVIEW_WIDTH = 350
+local MD_EDITOR_HEIGHT = 400
+
+local markdown_example = [[# H1 Title
+## H2 Title
+### H3 Title
+#### H4 Title
+##### H5 Title
+Normal paragraph with **bold** and _italic_ text and a [link](https://reaper.fm). Normal paragraph with **bold** and _italic_ text and a [link](https://reaper.fm). Normal paragraph with **bold** and _italic_ text and a [link](https://reaper.fm). Normal paragraph with **bold** and _italic_ text and a [link](https://reaper.fm).
+# Lists
+* List item 1
+* List item 2
+  * Sub list item 1
+  * ...
+# Tables
+| First Column | Second Column |
+|-|-|
+| Some **text** | A [link](https://reaper.fm) |
+# Code
+```
+function hello_world()
+  print("Hello World\n")
+end
+```
+# Blocks
+> Root block
+>> Inner block
+>>> Inner inner block
+]]
+
+function SettingsEditor:markdownTable()
+    local app_ctx   = AppContext:instance()
+    local ctx       = app_ctx.imgui_ctx
+
+    ImGui.BeginGroup(ctx)
+    ImGui.Selectable(ctx, "Stylesheet for new projects", true, 0, WIDGET_WIDTH + (self.preview_new_proj_markdown and PREVIEW_WIDTH + 4 or 0))
+
+    if ImGui.BeginChild(ctx, "aaaa##table_markdown_new", WIDGET_WIDTH, MD_EDITOR_HEIGHT) then
+        ImGui.PushID(ctx, "table_markdown_new_proj")
+        if ImGui.BeginTable(ctx, "", 6, 0, WIDGET_WIDTH) then
+            self:markdownTableHeaders()
+            self:markdownStyles(self.mdwidget_new_proj, self.new_project_markdown_style)
+            ImGui.TableNextRow(ctx)
+
+            self:stickersStyleRow(function() return self.new_project_sticker_size end, function(v) self.new_project_sticker_size = v end)
+            ImGui.EndTable(ctx)
+        end
+
+        -- BUTTONS
+        ImGui.Dummy(ctx,1,10)
+        local d = not (D.deepCompare(self:retrieveNewProjectMarkdownStyle(), self.new_project_markdown_style) and (S.getSetting("NewProjectStickerSize") == self.new_project_sticker_size))
+        if d then ImGui.PushStyleColor(ctx, ImGui.Col_Button, 0xFF0000FF) end
+        if ImGui.Button(ctx, "Save and apply !") then
+            S.setSetting("NewProjectMarkdown", self.new_project_markdown_style)
+            S.setSetting("NewProjectStickerSize", self.new_project_sticker_size)
+            if self.on_commit_new_project_style_callback then
+                self.on_commit_new_project_style_callback(D.deepCopy(self.new_project_markdown_style))
+            end
+        end
+        if d then ImGui.PopStyleColor(ctx) end
+        ImGui.SameLine(ctx)
+        if ImGui.Button(ctx, "Preview") then
+            local b = (self.preview_new_proj_markdown == true)
+            self.preview_new_proj_markdown = not b
+        end
+        ImGui.SameLine(ctx)
+        if ImGui.Button(ctx, "Copy ->") then
+            self.cur_project_markdown_style = D.deepCopy(self.new_project_markdown_style)
+            self.cur_project_sticker_size = self.new_project_sticker_size
+            self.mdwidget_cur_proj:setStyle(self.cur_project_markdown_style)
+            self.mdwidget_cur_proj:setText("")
+        end
+        if ImGui.IsItemHovered(ctx) then
+            ImGui.SetTooltip(ctx, "Copy these settings to Current Project panel")
+        end
+        ImGui.PopID(ctx)
+        ImGui.EndChild(ctx)
+    end
+
+    if self.preview_new_proj_markdown then
+        ImGui.SameLine(ctx)
+        ImGui.BeginGroup(ctx)
+        if ImGui.BeginChild(ctx, "##preview_left", PREVIEW_WIDTH, MD_EDITOR_HEIGHT) then
+            self.mdwidget_new_proj:setText(markdown_example)
+            self.mdwidget_new_proj:render(ctx)
+            ImGui.EndChild(ctx)
+        end
+
+        ImGui.Dummy(ctx,0,0)
+        local x, y    = ImGui.GetCursorScreenPos(ctx)
+        local sticker = Sticker:new("1:1:1F60D:Sticker Test", Notes:new(nil, false), 1)
+        local pr_res  = sticker:PreRender(ctx, self.new_project_sticker_size)
+        sticker:Render(ctx, pr_res, x, y)
+        ImGui.SetCursorScreenPos(ctx, x, y + pr_res.height)
+        ImGui.Dummy(ctx, 0, 0)
+
+        ImGui.EndGroup(ctx)
+    end
+
+    ImGui.EndGroup(ctx)
+
+    -- Vertical separator
+    ImGui.SameLine(ctx)
+    local cx, cy = ImGui.GetCursorScreenPos(ctx)
+    ImGui.DrawList_AddLine(ImGui.GetWindowDrawList(ctx), cx + 1, cy, cx + 1, cy + MD_EDITOR_HEIGHT + 20, 0x606060FF)
+    ImGui.Dummy(ctx,3,MD_EDITOR_HEIGHT)
+    ImGui.SameLine(ctx)
+
+    ImGui.BeginGroup(ctx)
+    ImGui.Selectable(ctx, "Stylesheet for current project", true, 0, WIDGET_WIDTH + (self.preview_cur_proj_markdown and PREVIEW_WIDTH + 4 or 0))
+
+    if self.preview_cur_proj_markdown then
+        ImGui.BeginGroup(ctx)
+        if ImGui.BeginChild(ctx, "##preview_right", PREVIEW_WIDTH, MD_EDITOR_HEIGHT) then
+            self.mdwidget_cur_proj:setText(markdown_example)
+            self.mdwidget_cur_proj:render(ctx)
+            ImGui.EndChild(ctx)
+        end
+
+        ImGui.Dummy(ctx,0,0)
+        local x, y    = ImGui.GetCursorScreenPos(ctx)
+        local sticker = Sticker:new("1:1:1F60D:Sticker Test", Notes:new(nil, false), 1)
+        local pr_res  = sticker:PreRender(ctx, self.cur_project_sticker_size)
+        sticker:Render(ctx, pr_res, x, y)
+        ImGui.SetCursorScreenPos(ctx, x, y + pr_res.height)
+        ImGui.Dummy(ctx, 0, 0)
+
+        ImGui.EndGroup(ctx)
+        ImGui.SameLine(ctx)
+    end
+
+    if ImGui.BeginChild(ctx, "bbbb##table_markdown_current", WIDGET_WIDTH, MD_EDITOR_HEIGHT) then
+        ImGui.PushID(ctx, "table_markdown_cur_proj")
+        if ImGui.BeginTable(ctx, "", 6, 0, WIDGET_WIDTH) then
+            self:markdownTableHeaders()
+            self:markdownStyles(self.mdwidget_cur_proj, self.cur_project_markdown_style)
+
+            ImGui.TableNextRow(ctx)
+            self:stickersStyleRow(function() return self.cur_project_sticker_size end, function(v) self.cur_project_sticker_size = v end)
+
+            ImGui.EndTable(ctx)
+        end
+
+        -- BUTTONS
+        ImGui.Dummy(ctx,1,10)
+        if ImGui.Button(ctx, "<- Copy") then
+            self.new_project_markdown_style = D.deepCopy(self.cur_project_markdown_style)
+            self.new_project_sticker_size   = self.cur_project_sticker_size
+            self.mdwidget_new_proj:setStyle(self.new_project_markdown_style)
+            self.mdwidget_new_proj:setText("")
+        end
+        if ImGui.IsItemHovered(ctx) then
+            ImGui.SetTooltip(ctx, "Copy these settings to New Project panel")
+        end
+        ImGui.SameLine(ctx)
+        if ImGui.Button(ctx, "Preview") then
+            local b = (self.preview_cur_proj_markdown == true)
+            self.preview_cur_proj_markdown = not b
+        end
+        ImGui.SameLine(ctx)
+        local d = not ((D.deepCompare(self:retrieveCurProjectMarkdownStyle(), self.cur_project_markdown_style)) and (D.RetrieveProjectStickerSize() == self.cur_project_sticker_size))
+        if d then ImGui.PushStyleColor(ctx, ImGui.Col_Button, 0xFF0000FF) end
+        if ImGui.Button(ctx, "Save and apply !") then
+            D.CommitProjectMarkdownStyle(self.cur_project_markdown_style)
+            D.CommitProjectStickerSize(self.cur_project_sticker_size)
+            if self.on_commit_current_project_style_callback then
+                self.on_commit_current_project_style_callback(D.deepCopy(self.cur_project_markdown_style))
+            end
+        end
+        if d then ImGui.PopStyleColor(ctx) end
+
+        ImGui.PopID(ctx)
+        ImGui.EndChild(ctx)
+    end
+    ImGui.EndGroup(ctx)
+end
+
 function SettingsEditor:draw()
     local app_ctx   = AppContext:instance()
     local ctx       = app_ctx.imgui_ctx
 
+    ImGui.PushFont(ctx, app_ctx.arial_font, S.getSetting("UIFontSize"))
+
     local b, open = ImGui.Begin(ctx, "Reannotate Settings##reannotate_settings_editor", true,
-        ImGui.WindowFlags_AlwaysAutoResize |
-        ImGui.WindowFlags_NoDocking |
-        ImGui.WindowFlags_NoResize |
-        ImGui.WindowFlags_TopMost |
-        ImGui.WindowFlags_NoCollapse
-    )
+    ImGui.WindowFlags_AlwaysAutoResize |
+    ImGui.WindowFlags_NoDocking |
+    ImGui.WindowFlags_NoResize |
+    ImGui.WindowFlags_TopMost |
+    ImGui.WindowFlags_NoCollapse)
 
     -- Set initiial position
     if ImGui.IsWindowAppearing(ctx) and self.pos then
@@ -50,65 +447,40 @@ function SettingsEditor:draw()
     end
 
     if b then
-        ImGui.SeparatorText(ctx, "Category Names")
-
-        if ImGui.BeginTable(ctx, "aaaa##table", 3) then
-            ImGui.TableSetupColumn(ctx, "")
-            ImGui.TableSetupColumn(ctx, "New Project")
-            ImGui.TableSetupColumn(ctx, "Current Project")
-            ImGui.TableHeadersRow(ctx)
-            for i=0, Notes.MAX_SLOTS-1 do
-                local slot = (i==Notes.MAX_SLOTS - 1) and (0) or (i+1)
-                ImGui.TableNextRow(ctx)
-                ImGui.TableNextColumn(ctx)
-
-                ImGui.PushItemFlag(ctx, ImGui.ItemFlags_NoTabStop, true)
-                ImGui.ColorEdit4(ctx, "##col_slot_" .. i, (Notes.SlotColor(slot) << 8) | 0xFF, ImGui.ColorEditFlags_NoPicker | ImGui.ColorEditFlags_NoDragDrop | ImGui.ColorEditFlags_NoInputs | ImGui.ColorEditFlags_NoBorder | ImGui.ColorEditFlags_NoTooltip)
-                ImGui.PopItemFlag(ctx)
-
-                --ImGui.Text(ctx,"y1")
-                ImGui.TableNextColumn(ctx)
-                ImGui.SetNextItemWidth(ctx, 150)
-                if slot ~= 0 then
-                    local lab   = S.getSetting("SlotLabel_" .. slot)
-                    local b, v  = ImGui.InputText(ctx, "##new_proj_edit_slot_" .. i, lab)
-                    if b then
-                        S.setSetting("SlotLabel_" .. slot, v)
-                    end
-                else
-                    ImGui.Text(ctx, " " .. Notes.SlotLabel(slot))
-                end
-                ImGui.TableNextColumn(ctx)
-                ImGui.SetNextItemWidth(ctx, 150)
-                if slot ~= 0 then
-                    local b, v = ImGui.InputText(ctx, "##cur_proj_edit_slot_" .. i, Notes.SlotLabel(slot))
-                    if b then
-                        Notes.SetSlotLabel(slot, v)
-                    end
-                else
-                    ImGui.Text(ctx, " " .. Notes.SlotLabel(slot))
-                end
+        if ImGui.BeginTabBar(ctx, "SettingsTab") then
+            if ImGui.BeginTabItem(ctx, "Categories", false) then
+                --    ImGui.TextWrapped(ctx, "You can rename categories here, for all new projets, or for the current project. Category names are used by the \"category\" special sticker, or when displaying counts and filters. This has no other role than letting you organize them to your will.")
+                self:categoryNamesTable()
+                ImGui.EndTabItem(ctx)
             end
-            ImGui.TableNextRow(ctx)
-            ImGui.TableNextColumn(ctx)
-            ImGui.TableNextColumn(ctx)
-            if ImGui.Button(ctx, "Reset to defaults##reset_global_labels_to_defaults_button") then
-                for i = 0, Notes.MAX_SLOTS-1 do
-                    S.resetSetting("SlotLabel_"..i)
-                end
-            end
-            ImGui.TableNextColumn(ctx)
-            if ImGui.Button(ctx, "Reset to defaults##reset_project_labels_to_defaults_button") then
-                for i = 0, Notes.MAX_SLOTS-1 do
-                    Notes.SetSlotLabel(i, S.getSettingSpec("SlotLabel_"..i).default )
-                end
-            end
+            if ImGui.BeginTabItem(ctx, "Appearance", false) then
+                --    ImGui.TextWrapped(ctx, "You can adjust markdown parameters for all new projects, or for the current project. Be careful, this changes the aspect of all existing tooltips, so their size will not fit their content anymore.")
 
-            ImGui.EndTable(ctx)
+                ImGui.SeparatorText(ctx, "General")
+                local ui_font_size = S.getSetting("UIFontSize")
+                local b, v = ImGui.SliderInt(ctx, "UI Font Size", ui_font_size, 8, 20)
+                if b then
+                    self.tmp_values = self.tmp_values or {}
+                    self.tmp_values["UIFontSize"] = v
+                end
+                if ImGui.IsItemDeactivatedAfterEdit(ctx) and self.tmp_values["UIFontSize"]  then
+                    S.setSetting("UIFontSize", self.tmp_values["UIFontSize"])
+                    self.tmp_values["UIFontSize"] = nil
+                end
+
+                ImGui.SeparatorText(ctx, "Markdown")
+
+                self:markdownTable()
+
+                ImGui.EndTabItem(ctx)
+            end
+            ImGui.EndTabBar(ctx)
         end
 
         ImGui.End(ctx)
     end
+
+    ImGui.PopFont(ctx)
 
     self.open       = open
     self.draw_count = self.draw_count + 1

--- a/Various/talagan_Reannotate/widgets/sticker_editor.lua
+++ b/Various/talagan_Reannotate/widgets/sticker_editor.lua
@@ -8,6 +8,8 @@ local AppContext    = require "classes/app_context"
 local EmojImGui     = require "emojimgui"
 local Sticker       = require "classes/sticker"
 
+local D             = require "modules/defines"
+
 local StickerEditor = {}
 StickerEditor.__index = StickerEditor
 
@@ -23,7 +25,7 @@ function StickerEditor:_initialize(sticker, thing, slot)
   self.rand        = math.random()
   self.open        = true
   if not sticker then
-    sticker = Sticker:new("1:1::", thing, slot)
+    sticker = Sticker:new("1:1::", thing.notes, slot)
     self.new_record       = true
     self.packed_code_was  = nil
   else
@@ -51,6 +53,10 @@ function StickerEditor:title()
   else
     return "Sticker edit"
   end
+end
+
+function StickerEditor:stickerSize()
+  return D.RetrieveProjectStickerSize()
 end
 
 function StickerEditor:draw(color)
@@ -103,9 +109,13 @@ function StickerEditor:draw(color)
       ImGui.PushStyleColor(ctx, ImGui.Col_ChildBg, (self.sticker.icon.font_name == 'OpenMoji') and (0x9EB8FFFF) or (0))
     end
 
+
+---@diagnostic disable-next-line: undefined-field
     if ImGui.BeginChild(ctx, "Smiley prev", 50, 50, ImGui.ChildFlags_Borders, ImGui.WindowFlags_NoScrollbar) then
       if self.sticker and self.sticker.icon then
         local font = EmojImGui.Asset.Font(ctx, self.sticker.icon.font_name)
+
+---@diagnostic disable-next-line: redundant-parameter
         ImGui.PushFont(ctx, font, 28)
         local iw, ih = ImGui.CalcTextSize(ctx, self.sticker.icon.utf8)
         local cw, ch = ImGui.GetContentRegionAvail(ctx)
@@ -160,7 +170,7 @@ function StickerEditor:draw(color)
     else
       ImGui.Text(ctx, "Sticker preview")
       ImGui.SameLine(ctx)
-      local metrics = self.sticker:PreRender(ctx, Sticker.DEFAULT_SIZE)
+      local metrics = self.sticker:PreRender(ctx, self:stickerSize())
       local xs, ys = ImGui.GetCursorScreenPos(ctx)
       self.sticker:Render(ctx, metrics, xs, ys, color, 0x000000FF)
       ImGui.Dummy(ctx,0,0)


### PR DESCRIPTION
Update for Reannotate, with the following changelog : 

  - [Feature] The markdown stylesheet is now customizable
  - [Feature] UI Font size is now customizable
  - [Feature] Note editor's width is now remembered
  - [Bug Fix] Tooltips with vertical scrollbars could affect the layout of other tooltips shown immediately after
  - [Rework] Moved project notes to the transport zone instead of the time ruler (will be used for regions / markers ?)
  - [Rework] Optimizations